### PR TITLE
Implement encryption

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -523,10 +523,10 @@ preferred-modules=
 ignored-parents=
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=20
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5
@@ -550,7 +550,7 @@ max-returns=10
 max-statements=200
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=1
+min-public-methods=0
 
 
 [EXCEPTIONS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -551,11 +551,3 @@ max-statements=200
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=0
-
-
-[EXCEPTIONS]
-
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-02-05 18:44+0100\n"
-"PO-Revision-Date: 2023-02-05 18:48+0100\n"
+"POT-Creation-Date: 2023-02-21 21:48+0100\n"
+"PO-Revision-Date: 2023-02-21 21:50+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -29,11 +29,11 @@ msgstr "Synchronisation des dépôts et du trousseau de clés..."
 msgid "Querying IP geolocation informations..."
 msgstr "Interrogation des informations de géolocalisation IP..."
 
-#: src/archcraftsman.py:80 src/installer.py:193 src/shell.py:104
+#: src/archcraftsman.py:80 src/installer.py:195 src/shell.py:104
 msgid "Script execution interrupted by the user !"
 msgstr "Exécution du script interrompue par l'utilisateur !"
 
-#: src/archcraftsman.py:83 src/installer.py:197 src/shell.py:107
+#: src/archcraftsman.py:83 src/installer.py:199 src/shell.py:107
 msgid "A subprocess execution failed ! See the following error: %s"
 msgstr ""
 "L'exécution d'un sous-processus a échoué ! L'erreur suivante s'est "
@@ -75,21 +75,25 @@ msgstr "Types de swap supportés : "
 msgid "Do you want a separated Home ? (Y/n) : "
 msgstr "Voulez-vous un Home séparé ? (O/n) : "
 
-#: src/autopart.py:154 src/envsetup.py:66 src/manualpart.py:125
+#: src/autopart.py:53 src/autopart.py:57
+msgid "Do you want to encrypt the %s partition ? (y/N) : "
+msgstr "Voulez-vous chiffrer la partition %s ? (o/N) : "
+
+#: src/autopart.py:182 src/envsetup.py:66 src/manualpart.py:110
 #: src/systemsetup.py:133
 msgid "Summary of choices :"
 msgstr "Résumé des choix :"
 
-#: src/autopart.py:158 src/manualpart.py:130
+#: src/autopart.py:186 src/manualpart.py:115
 msgid "Swapfile size : %s"
 msgstr "Taille du fichier d'échange : %s"
 
-#: src/autopart.py:159 src/envsetup.py:69 src/manualpart.py:131
+#: src/autopart.py:187 src/envsetup.py:69 src/manualpart.py:116
 #: src/systemsetup.py:148
 msgid "Is the informations correct ? (y/N) : "
 msgstr "Les informations sont-elles correctes ? (o/N) : "
 
-#: src/autopart.py:161 src/manualpart.py:133
+#: src/autopart.py:189 src/manualpart.py:118
 msgid "Do you want to change the partitioning mode ? (y/N) : "
 msgstr "Voulez-vous changer de mode de partitionnement ? (o/N) : "
 
@@ -259,71 +263,79 @@ msgstr "La keymap de votre installation : %s"
 msgid "Unmounting partitions..."
 msgstr "Démontage des partitions..."
 
-#: src/installer.py:43
+#: src/installer.py:47
 msgid "Partitioning :"
 msgstr "Partitionnement :"
 
-#: src/installer.py:44
+#: src/installer.py:48
 msgid "Do you want an automatic partitioning ? (y/N) : "
 msgstr "Voulez-vous un partitionnement automatique ? (o/N) : "
 
-#: src/installer.py:51
+#: src/installer.py:55
 msgid "Formatting and mounting partitions..."
 msgstr "Formatage et montage des partitions..."
 
-#: src/installer.py:63
+#: src/installer.py:57 src/installer.py:69
+msgid "Formatting %s..."
+msgstr "Formatage de %s..."
+
+#: src/installer.py:59 src/installer.py:71
+msgid "Mounting %s..."
+msgstr "Montage de %s..."
+
+#: src/installer.py:74
 msgid "Updating mirrors..."
 msgstr "Mise à jour des miroirs..."
 
-#: src/installer.py:94
+#: src/installer.py:105
 msgid "Installation of the base..."
 msgstr "Installation de la base..."
 
-#: src/installer.py:97
+#: src/installer.py:108
 msgid "System configuration..."
 msgstr "Configuration du système..."
 
-#: src/installer.py:117
+#: src/installer.py:128
 msgid "Locales configuration..."
 msgstr "Configuration des locales..."
 
-#: src/installer.py:121
+#: src/installer.py:132
 msgid "Installation of the remaining packages..."
 msgstr "Installation des paquets restants..."
 
-#: src/installer.py:130
+#: src/installer.py:141
 msgid "Creation and activation of the swapfile..."
 msgstr "Création et activation du fichier d'échange..."
 
-#: src/installer.py:146
+#: src/installer.py:157
 msgid "Generating fstab..."
 msgstr "Génération du fstab..."
 
-#: src/installer.py:149
+#: src/installer.py:160
 msgid "Network configuration..."
 msgstr "Configuration du réseau..."
 
-#: src/installer.py:154
+#: src/installer.py:165
 msgid "Installation and configuration of the grub..."
 msgstr "Installation et configuration du grub..."
 
-#: src/installer.py:157
+#: src/installer.py:168
 msgid "Users configuration..."
 msgstr "Configuration des utilisateurs..."
 
-#: src/installer.py:158
+#: src/installer.py:169
 msgid "Root account configuration..."
 msgstr "Configuration du compte Root..."
 
-#: src/installer.py:162
+#: src/installer.py:173
 msgid "%s account configuration..."
 msgstr "Configuration du compte %s..."
 
-#: src/installer.py:175
+#: src/installer.py:186
 msgid "Extra packages configuration if needed..."
 msgstr "Configuration de paquets supplémentaires si nécessaire..."
 
-#: src/installer.py:181
+#: src/installer.py:192
 msgid "Installation complete ! You can reboot your system."
 msgstr "L'installation est terminée ! Vous pouvez redémarrer votre système."
 
@@ -331,15 +343,15 @@ msgstr "L'installation est terminée ! Vous pouvez redémarrer votre système."
 msgid "Configuring live environment..."
 msgstr "Configuration de l'environnement live..."
 
-#: src/manualpart.py:27 src/manualpart.py:38
+#: src/manualpart.py:26 src/manualpart.py:37
 msgid "Manual partitioning :"
 msgstr "Partitionnement manuel :"
 
-#: src/manualpart.py:28 src/manualpart.py:39
+#: src/manualpart.py:27 src/manualpart.py:38
 msgid "Partitioned drives so far : %s"
 msgstr "Disques partitionnés jusqu'à présent : %s"
 
-#: src/manualpart.py:31
+#: src/manualpart.py:30
 msgid ""
 "Which drive do you want to partition ? (type the entire name, for example '/"
 "dev/sda') : "
@@ -347,91 +359,71 @@ msgstr ""
 "Quel disque souhaitez-vous partitionner ? (tapez le nom complet, par exemple "
 "'/dev/sda') : "
 
-#: src/manualpart.py:33
+#: src/manualpart.py:32
 msgid "The chosen target drive doesn't exist."
 msgstr "Le disque cible choisi n'existe pas."
 
-#: src/manualpart.py:41
+#: src/manualpart.py:40
 msgid "Do you want to partition an other drive ? (y/N) : "
 msgstr "Voulez-vous partitionner un autre disque ? (o/N) : "
 
-#: src/manualpart.py:54
+#: src/manualpart.py:53
 msgid "Detected target drive partitions : %s"
 msgstr "Partitions du disque cible détectées : %s"
 
-#: src/manualpart.py:56
+#: src/manualpart.py:55
 msgid "Partition :"
 msgstr "Partition :"
 
-#: src/manualpart.py:59 src/manualpart.py:64
+#: src/manualpart.py:58 src/manualpart.py:63
 msgid "What is the role of this partition ? (%s) : "
 msgstr "Quel est le rôle de cette partition ? (%s) : "
 
-#: src/manualpart.py:60 src/manualpart.py:65
+#: src/manualpart.py:59 src/manualpart.py:64
 msgid "Partition type '%s' is not supported."
 msgstr "Le type de partition '%s' n'est pas supporté."
 
-#: src/manualpart.py:61 src/manualpart.py:66
+#: src/manualpart.py:60 src/manualpart.py:65
 msgid "Supported partition types : "
 msgstr "Types de partition supportés : "
 
-#: src/manualpart.py:70 src/manualpart.py:86 src/manualpart.py:92
-msgid "Format the partition ? (Y/n) : "
-msgstr "Formater la partition ? (O/n) : "
-
-#: src/manualpart.py:102
+#: src/manualpart.py:86
 msgid "What is the mounting point of this partition ? : "
 msgstr "Quel est le point de montage de cette partition ? : "
 
-#: src/manualpart.py:104
-msgid "Format the %s partition ? (Y/n) : "
-msgstr "Formater la partition %s ? (O/n) : "
-
-#: src/manualpart.py:108
+#: src/manualpart.py:91
 msgid "The EFI partition is required for system installation."
 msgstr "La partition EFI est nécessaire pour l'installation du système."
 
-#: src/manualpart.py:113
+#: src/manualpart.py:96
 msgid "The Root partition is required for system installation."
 msgstr "La partition Root est nécessaire pour l'installation du système."
 
-#: src/manualpart.py:119
+#: src/manualpart.py:103
 msgid "The Boot partition is required for system installation."
 msgstr "La partition Boot est nécessaire pour l'installation du système."
 
-#: src/partition.py:80
+#: src/partition.py:104
+msgid "Format the partition ? (Y/n) : "
+msgstr "Formater la partition ? (O/n) : "
+
+#: src/partition.py:125
 msgid "Do you want to encrypt this partition ? (y/N) : "
 msgstr "Voulez-vous chiffrer cette partition ? (o/N) : "
 
-#: src/partition.py:86
-msgid "What will be the encrypted block name ? : "
-msgstr "Quel sera le nom de bloc chiffré ? : "
-
-#: src/partition.py:89
-msgid "Invalid encrypted block name."
-msgstr "Nom de bloc chiffré invalide."
-
-#: src/partition.py:94
-msgid ""
-"Enter the encrypted block password (it will be asked at boot to decrypt the "
-"partition) : "
-msgstr ""
-"Entrez le mot de passe du bloc chiffré (il sera demandé au démarrage pour "
-"déchiffrer la partition) : "
-
-#: src/partition.py:103
+#: src/partition.py:140
 msgid "yes"
 msgstr "oui"
 
-#: src/partition.py:105
+#: src/partition.py:142
 msgid "no"
 msgstr "non"
 
-#: src/partition.py:112
+#: src/partition.py:149
 msgid "%s : %s"
 msgstr "%s : %s"
 
-#: src/partition.py:113
+#: src/partition.py:150
 msgid "%s : %s (mounting point : %s, format %s, format type %s)"
 msgstr "%s : %s (point de montage : %s, formater %s, type de formatage %s)"
 
@@ -646,25 +638,43 @@ msgstr "Quel type de formatage voulez-vous ? (%s) : "
 msgid "Supported format types : "
 msgstr "Types de formatage supportés : "
 
-#: src/utils.py:70
+#: src/utils.py:68
+msgid "What will be the encrypted block name ? : "
+msgstr "Quel sera le nom de bloc chiffré ? : "
+
+#: src/utils.py:71
+msgid "Invalid encrypted block name."
+msgstr "Nom de bloc chiffré invalide."
+
+#: src/utils.py:88
 msgid "Enter it again to confirm : "
 msgstr "Saisissez le à nouveau pour confirmer : "
 
-#: src/utils.py:72
+#: src/utils.py:90
 msgid "Passwords entered don't match."
 msgstr "Les mots de passe saisis ne correspondent pas."
 
-#: src/utils.py:124
+#: src/utils.py:142
 msgid "Help :"
 msgstr "Aide :"
 
-#: src/utils.py:163
+#: src/utils.py:181
 msgid "The input must not be empty."
 msgstr "La saisie ne doit pas être vide."
 
-#: src/utils.py:268
+#: src/utils.py:286
 msgid "Press any key to continue..."
 msgstr "Appuyez sur n'importe quelle touche pour continuer..."
+
+#~ msgid "Format the %s partition ? (Y/n) : "
+#~ msgstr "Formater la partition %s ? (O/n) : "
+
+#~ msgid ""
+#~ "Enter the encrypted block password (it will be asked at boot to decrypt "
+#~ "the partition) : "
+#~ msgstr ""
+#~ "Entrez le mot de passe du bloc chiffré (il sera demandé au démarrage pour "
+#~ "déchiffrer la partition) : "
 
 #~ msgid "ROOT partition : %s (mounting point : %s, format type %s)"
 #~ msgstr "Partition ROOT : %s (point de montage : %s, type de formatage %s)"

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-02-21 21:48+0100\n"
-"PO-Revision-Date: 2023-02-21 21:50+0100\n"
+"POT-Creation-Date: 2023-02-21 23:09+0100\n"
+"PO-Revision-Date: 2023-02-21 23:10+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -29,11 +29,11 @@ msgstr "Synchronisation des dépôts et du trousseau de clés..."
 msgid "Querying IP geolocation informations..."
 msgstr "Interrogation des informations de géolocalisation IP..."
 
-#: src/archcraftsman.py:80 src/installer.py:195 src/shell.py:104
+#: src/archcraftsman.py:80 src/installer.py:165 src/shell.py:104
 msgid "Script execution interrupted by the user !"
 msgstr "Exécution du script interrompue par l'utilisateur !"
 
-#: src/archcraftsman.py:83 src/installer.py:199 src/shell.py:107
+#: src/archcraftsman.py:83 src/installer.py:169 src/shell.py:107
 msgid "A subprocess execution failed ! See the following error: %s"
 msgstr ""
 "L'exécution d'un sous-processus a échoué ! L'erreur suivante s'est "
@@ -259,83 +259,67 @@ msgstr "La langue de votre installation : %s"
 msgid "Your installation's keymap : %s"
 msgstr "La keymap de votre installation : %s"
 
-#: src/installer.py:23
-msgid "Unmounting partitions..."
-msgstr "Démontage des partitions..."
-
-#: src/installer.py:47
+#: src/installer.py:31
 msgid "Partitioning :"
 msgstr "Partitionnement :"
 
-#: src/installer.py:48
+#: src/installer.py:32
 msgid "Do you want an automatic partitioning ? (y/N) : "
 msgstr "Voulez-vous un partitionnement automatique ? (o/N) : "
 
-#: src/installer.py:55
-msgid "Formatting and mounting partitions..."
-msgstr "Formatage et montage des partitions..."
-
-#: src/installer.py:57 src/installer.py:69
-msgid "Formatting %s..."
-msgstr "Formatage de %s..."
-
-#: src/installer.py:59 src/installer.py:71
-msgid "Mounting %s..."
-msgstr "Montage de %s..."
-
-#: src/installer.py:74
+#: src/installer.py:41
 msgid "Updating mirrors..."
 msgstr "Mise à jour des miroirs..."
 
-#: src/installer.py:105
+#: src/installer.py:73
 msgid "Installation of the base..."
 msgstr "Installation de la base..."
 
-#: src/installer.py:108
+#: src/installer.py:76
 msgid "System configuration..."
 msgstr "Configuration du système..."
 
-#: src/installer.py:128
+#: src/installer.py:96
 msgid "Locales configuration..."
 msgstr "Configuration des locales..."
 
-#: src/installer.py:132
+#: src/installer.py:100
 msgid "Installation of the remaining packages..."
 msgstr "Installation des paquets restants..."
 
-#: src/installer.py:141
+#: src/installer.py:110
 msgid "Creation and activation of the swapfile..."
 msgstr "Création et activation du fichier d'échange..."
 
-#: src/installer.py:157
+#: src/installer.py:126
 msgid "Generating fstab..."
 msgstr "Génération du fstab..."
 
-#: src/installer.py:160
+#: src/installer.py:129
 msgid "Network configuration..."
 msgstr "Configuration du réseau..."
 
-#: src/installer.py:165
+#: src/installer.py:134
 msgid "Installation and configuration of the grub..."
 msgstr "Installation et configuration du grub..."
 
-#: src/installer.py:168
+#: src/installer.py:137
 msgid "Users configuration..."
 msgstr "Configuration des utilisateurs..."
 
-#: src/installer.py:169
+#: src/installer.py:138
 msgid "Root account configuration..."
 msgstr "Configuration du compte Root..."
 
-#: src/installer.py:173
+#: src/installer.py:142
 msgid "%s account configuration..."
 msgstr "Configuration du compte %s..."
 
-#: src/installer.py:186
+#: src/installer.py:156
 msgid "Extra packages configuration if needed..."
 msgstr "Configuration de paquets supplémentaires si nécessaire..."
 
-#: src/installer.py:192
+#: src/installer.py:162
 msgid "Installation complete ! You can reboot your system."
 msgstr "L'installation est terminée ! Vous pouvez redémarrer votre système."
 
@@ -426,6 +410,34 @@ msgstr "%s : %s"
 #: src/partition.py:150
 msgid "%s : %s (mounting point : %s, format %s, format type %s)"
 msgstr "%s : %s (point de montage : %s, formater %s, type de formatage %s)"
+
+#: src/partition.py:167
+msgid "Formatting %s..."
+msgstr "Formatage de %s..."
+
+#: src/partition.py:175
+msgid "Opening %s..."
+msgstr "Ouverture de %s..."
+
+#: src/partition.py:193
+msgid "Mounting %s..."
+msgstr "Montage de %s..."
+
+#: src/partition.py:207
+msgid "Unmounting %s..."
+msgstr "Démontage de %s..."
+
+#: src/partition.py:210
+msgid "Closing %s..."
+msgstr "Fermeture de %s..."
+
+#: src/partitioninginfo.py:33
+msgid "Formatting and mounting partitions..."
+msgstr "Formatage et montage des partitions..."
+
+#: src/partitioninginfo.py:53
+msgid "Unmounting partitions..."
+msgstr "Démontage des partitions..."
 
 #: src/shell.py:20 src/systemsetup.py:40
 msgid "Kernel '%s' is not supported."

--- a/locales/fr.po
+++ b/locales/fr.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-01-22 17:25+0100\n"
-"PO-Revision-Date: 2023-01-22 17:25+0100\n"
+"POT-Creation-Date: 2023-02-05 18:44+0100\n"
+"PO-Revision-Date: 2023-02-05 18:48+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr_FR\n"
@@ -29,21 +29,21 @@ msgstr "Synchronisation des dépôts et du trousseau de clés..."
 msgid "Querying IP geolocation informations..."
 msgstr "Interrogation des informations de géolocalisation IP..."
 
-#: src/archcraftsman.py:80 src/installer.py:205 src/shell.py:104
+#: src/archcraftsman.py:80 src/installer.py:193 src/shell.py:104
 msgid "Script execution interrupted by the user !"
 msgstr "Exécution du script interrompue par l'utilisateur !"
 
-#: src/archcraftsman.py:83 src/installer.py:209 src/shell.py:107
+#: src/archcraftsman.py:83 src/installer.py:197 src/shell.py:107
 msgid "A subprocess execution failed ! See the following error: %s"
 msgstr ""
 "L'exécution d'un sous-processus a échoué ! L'erreur suivante s'est "
 "produite : %s"
 
-#: src/autopart.py:26
+#: src/autopart.py:25
 msgid "Automatic partitioning :"
 msgstr "Partitionnement automatique :"
 
-#: src/autopart.py:29
+#: src/autopart.py:28
 msgid ""
 "On which drive should Archlinux be installed ? (type the entire name, for "
 "example '/dev/sda') : "
@@ -51,140 +51,107 @@ msgstr ""
 "Sur quel disque Archlinux doit-il être installé ? (tapez le nom complet, par "
 "exemple '/dev/sda') : "
 
-#: src/autopart.py:31 src/autopart.py:34
+#: src/autopart.py:30 src/autopart.py:33
 msgid "You need to choose a target drive."
 msgstr "Vous devez choisir un disque cible."
 
-#: src/autopart.py:44
+#: src/autopart.py:43
 msgid "Do you want to install Arch Linux next to other systems ? (Y/n) : "
 msgstr "Voulez-vous installer Arch Linux à côté des autres systèmes ? (O/n) : "
 
-#: src/autopart.py:48
+#: src/autopart.py:47
 msgid "Swap type '%s' is not supported."
 msgstr "Le type de swap '%s' n'est pas supporté."
 
-#: src/autopart.py:48
+#: src/autopart.py:47
 msgid "What type of Swap do you want ? (%s) : "
 msgstr "Quel type de swap voulez-vous ? (%s) : "
 
-#: src/autopart.py:49
+#: src/autopart.py:48
 msgid "Supported Swap types : "
 msgstr "Types de swap supportés : "
 
-#: src/autopart.py:51
+#: src/autopart.py:50
 msgid "Do you want a separated Home ? (Y/n) : "
 msgstr "Voulez-vous un Home séparé ? (O/n) : "
 
-#: src/autopart.py:164 src/envsetup.py:66 src/manualpart.py:110
-#: src/systemsetup.py:131
+#: src/autopart.py:154 src/envsetup.py:66 src/manualpart.py:125
+#: src/systemsetup.py:133
 msgid "Summary of choices :"
 msgstr "Résumé des choix :"
 
-#: src/autopart.py:167 src/manualpart.py:113
-msgid "yes"
-msgstr "oui"
-
-#: src/autopart.py:169 src/manualpart.py:115
-msgid "no"
-msgstr "non"
-
-#: src/autopart.py:171 src/manualpart.py:117
-msgid "EFI partition : %s (mounting point : %s, format %s, format type %s)"
-msgstr ""
-"Partition EFI : %s (point de montage : %s, formater %s, type de formatage %s)"
-
-#: src/autopart.py:175 src/manualpart.py:121
-msgid "ROOT partition : %s (mounting point : %s, format type %s)"
-msgstr "Partition ROOT : %s (point de montage : %s, type de formatage %s)"
-
-#: src/autopart.py:179 src/manualpart.py:125
-msgid "Home partition : %s (mounting point : %s, format %s, format type %s)"
-msgstr ""
-"Partition Home : %s (point de montage : %s, formater %s, type de formatage "
-"%s)"
-
-#: src/autopart.py:183 src/manualpart.py:129
-msgid "Swap partition : %s"
-msgstr "Partition Swap : %s"
-
-#: src/autopart.py:185 src/manualpart.py:131
-msgid "Other partition : %s (mounting point : %s, format %s, format type %s)"
-msgstr ""
-"Autre partition : %s (point de montage : %s, formater %s, type de formatage "
-"%s)"
-
-#: src/autopart.py:189 src/manualpart.py:135
+#: src/autopart.py:158 src/manualpart.py:130
 msgid "Swapfile size : %s"
 msgstr "Taille du fichier d'échange : %s"
 
-#: src/autopart.py:190 src/envsetup.py:69 src/manualpart.py:136
-#: src/systemsetup.py:146
+#: src/autopart.py:159 src/envsetup.py:69 src/manualpart.py:131
+#: src/systemsetup.py:148
 msgid "Is the informations correct ? (y/N) : "
 msgstr "Les informations sont-elles correctes ? (o/N) : "
 
-#: src/autopart.py:192 src/manualpart.py:138
+#: src/autopart.py:161 src/manualpart.py:133
 msgid "Do you want to change the partitioning mode ? (y/N) : "
 msgstr "Voulez-vous changer de mode de partitionnement ? (o/N) : "
 
-#: src/bundles/budgie.py:29 src/bundles/cinnamon.py:29
-#: src/bundles/cutefish.py:27 src/bundles/lxqt.py:29 src/bundles/mate.py:36
-#: src/bundles/xfce.py:37
+#: src/bundles/budgie.py:30 src/bundles/cinnamon.py:30
+#: src/bundles/cutefish.py:28 src/bundles/lxqt.py:30 src/bundles/mate.py:37
+#: src/bundles/xfce.py:38
 msgid ""
 "The display manager to install is '%s'. Do you want to install it ? (Y/n) : "
 msgstr ""
 "Le gestionnaire d'affichage à installer est '%s'. Voulez-vous l'installer ? "
 "(O/n) : "
 
-#: src/bundles/budgie.py:33 src/bundles/cinnamon.py:33
-#: src/bundles/cutefish.py:31 src/bundles/deepin.py:26
-#: src/bundles/enlightenment.py:24 src/bundles/gnome.py:27 src/bundles/i3.py:25
-#: src/bundles/lxqt.py:33 src/bundles/mate.py:29 src/bundles/plasma.py:33
-#: src/bundles/sway.py:28 src/bundles/xfce.py:30
-msgid "Desktop environment : %s"
-msgstr "Environnement de bureau : %s"
-
 #: src/bundles/budgie.py:34 src/bundles/cinnamon.py:34
 #: src/bundles/cutefish.py:32 src/bundles/deepin.py:27
 #: src/bundles/enlightenment.py:25 src/bundles/gnome.py:28 src/bundles/i3.py:26
 #: src/bundles/lxqt.py:34 src/bundles/mate.py:30 src/bundles/plasma.py:34
 #: src/bundles/sway.py:29 src/bundles/xfce.py:31
+msgid "Desktop environment : %s"
+msgstr "Environnement de bureau : %s"
+
+#: src/bundles/budgie.py:35 src/bundles/cinnamon.py:35
+#: src/bundles/cutefish.py:33 src/bundles/deepin.py:28
+#: src/bundles/enlightenment.py:26 src/bundles/gnome.py:29 src/bundles/i3.py:27
+#: src/bundles/lxqt.py:35 src/bundles/mate.py:31 src/bundles/plasma.py:35
+#: src/bundles/sway.py:30 src/bundles/xfce.py:32
 msgid "Display manager : %s"
 msgstr "Gestionnaire d'affichage : %s"
 
-#: src/bundles/budgie.py:34 src/bundles/cinnamon.py:34
-#: src/bundles/cutefish.py:32 src/bundles/enlightenment.py:25
-#: src/bundles/i3.py:26 src/bundles/lxqt.py:34 src/bundles/mate.py:30
-#: src/bundles/sway.py:29 src/bundles/xfce.py:31
+#: src/bundles/budgie.py:35 src/bundles/cinnamon.py:35
+#: src/bundles/cutefish.py:33 src/bundles/enlightenment.py:26
+#: src/bundles/i3.py:27 src/bundles/lxqt.py:35 src/bundles/mate.py:31
+#: src/bundles/sway.py:30 src/bundles/xfce.py:32
 msgid "none"
 msgstr "aucun"
 
-#: src/bundles/copyacm.py:17
+#: src/bundles/copyacm.py:18
 msgid "Copy ArchCraftsman to the new system."
 msgstr "Copier ArchCraftsman sur le nouveau système."
 
-#: src/bundles/cups.py:22
+#: src/bundles/cups.py:23
 msgid "Install Cups."
 msgstr "Installer Cups."
 
-#: src/bundles/deepin.py:29 src/bundles/mate.py:32 src/bundles/plasma.py:36
-#: src/bundles/xfce.py:33
+#: src/bundles/deepin.py:30 src/bundles/mate.py:33 src/bundles/plasma.py:37
+#: src/bundles/xfce.py:34
 msgid "Install a minimal environment."
 msgstr "Installer un environnement minimal."
 
-#: src/bundles/deepin.py:33 src/bundles/gnome.py:32 src/bundles/mate.py:39
-#: src/bundles/plasma.py:42 src/bundles/xfce.py:40
+#: src/bundles/deepin.py:34 src/bundles/gnome.py:33 src/bundles/mate.py:40
+#: src/bundles/plasma.py:43 src/bundles/xfce.py:41
 msgid "Install a minimal environment ? (y/N/?) : "
 msgstr "Installer un environnement minimal ? (o/N/?) : "
 
-#: src/bundles/deepin.py:35 src/bundles/gnome.py:34 src/bundles/mate.py:41
-#: src/bundles/plasma.py:44 src/bundles/xfce.py:42
+#: src/bundles/deepin.py:36 src/bundles/gnome.py:35 src/bundles/mate.py:42
+#: src/bundles/plasma.py:45 src/bundles/xfce.py:43
 msgid ""
 "If yes, the script will not install any extra packages, only base packages."
 msgstr ""
 "Si oui, le script n'installera pas de paquets supplémentaires, seulement les "
 "paquets de base."
 
-#: src/bundles/grmlzsh.py:21
+#: src/bundles/grmlzsh.py:22
 msgid "Install ZSH with GRML configuration."
 msgstr "Installer ZSH avec la configuration GRML."
 
@@ -224,19 +191,19 @@ msgstr "Installer le pilote propriétaire Nvidia."
 msgid "Install PipeWire."
 msgstr "Installer PipeWire."
 
-#: src/bundles/plasma.py:38
+#: src/bundles/plasma.py:39
 msgid "Install Wayland support for the plasma session."
 msgstr "Installer le support Wayland pour la session plasma."
 
-#: src/bundles/plasma.py:45
+#: src/bundles/plasma.py:46
 msgid "Install Wayland support for the plasma session ? (y/N) : "
 msgstr "Installer le support Wayland pour la session plasma ? (o/N) : "
 
-#: src/bundles/terminus.py:21
+#: src/bundles/terminus.py:22
 msgid "Install terminus console font."
 msgstr "Installer la police de console Terminus."
 
-#: src/bundles/zram.py:20
+#: src/bundles/zram.py:21
 msgid "Install and enable ZRAM."
 msgstr "Installer et activer ZRAM."
 
@@ -288,75 +255,75 @@ msgstr "La langue de votre installation : %s"
 msgid "Your installation's keymap : %s"
 msgstr "La keymap de votre installation : %s"
 
-#: src/installer.py:22
+#: src/installer.py:23
 msgid "Unmounting partitions..."
 msgstr "Démontage des partitions..."
 
-#: src/installer.py:42
+#: src/installer.py:43
 msgid "Partitioning :"
 msgstr "Partitionnement :"
 
-#: src/installer.py:43
+#: src/installer.py:44
 msgid "Do you want an automatic partitioning ? (y/N) : "
 msgstr "Voulez-vous un partitionnement automatique ? (o/N) : "
 
-#: src/installer.py:49
+#: src/installer.py:51
 msgid "Formatting and mounting partitions..."
 msgstr "Formatage et montage des partitions..."
 
-#: src/installer.py:76
+#: src/installer.py:63
 msgid "Updating mirrors..."
 msgstr "Mise à jour des miroirs..."
 
-#: src/installer.py:107
+#: src/installer.py:94
 msgid "Installation of the base..."
 msgstr "Installation de la base..."
 
-#: src/installer.py:110
+#: src/installer.py:97
 msgid "System configuration..."
 msgstr "Configuration du système..."
 
-#: src/installer.py:130
+#: src/installer.py:117
 msgid "Locales configuration..."
 msgstr "Configuration des locales..."
 
-#: src/installer.py:134
+#: src/installer.py:121
 msgid "Installation of the remaining packages..."
 msgstr "Installation des paquets restants..."
 
-#: src/installer.py:142
+#: src/installer.py:130
 msgid "Creation and activation of the swapfile..."
 msgstr "Création et activation du fichier d'échange..."
 
-#: src/installer.py:158
+#: src/installer.py:146
 msgid "Generating fstab..."
 msgstr "Génération du fstab..."
 
-#: src/installer.py:161
+#: src/installer.py:149
 msgid "Network configuration..."
 msgstr "Configuration du réseau..."
 
-#: src/installer.py:166
+#: src/installer.py:154
 msgid "Installation and configuration of the grub..."
 msgstr "Installation et configuration du grub..."
 
-#: src/installer.py:169
+#: src/installer.py:157
 msgid "Users configuration..."
 msgstr "Configuration des utilisateurs..."
 
-#: src/installer.py:170
+#: src/installer.py:158
 msgid "Root account configuration..."
 msgstr "Configuration du compte Root..."
 
-#: src/installer.py:174
+#: src/installer.py:162
 msgid "%s account configuration..."
 msgstr "Configuration du compte %s..."
 
-#: src/installer.py:187
+#: src/installer.py:175
 msgid "Extra packages configuration if needed..."
 msgstr "Configuration de paquets supplémentaires si nécessaire..."
 
-#: src/installer.py:193
+#: src/installer.py:181
 msgid "Installation complete ! You can reboot your system."
 msgstr "L'installation est terminée ! Vous pouvez redémarrer votre système."
 
@@ -364,15 +331,15 @@ msgstr "L'installation est terminée ! Vous pouvez redémarrer votre système."
 msgid "Configuring live environment..."
 msgstr "Configuration de l'environnement live..."
 
-#: src/manualpart.py:26 src/manualpart.py:36
+#: src/manualpart.py:27 src/manualpart.py:38
 msgid "Manual partitioning :"
 msgstr "Partitionnement manuel :"
 
-#: src/manualpart.py:27 src/manualpart.py:37
+#: src/manualpart.py:28 src/manualpart.py:39
 msgid "Partitioned drives so far : %s"
 msgstr "Disques partitionnés jusqu'à présent : %s"
 
-#: src/manualpart.py:30
+#: src/manualpart.py:31
 msgid ""
 "Which drive do you want to partition ? (type the entire name, for example '/"
 "dev/sda') : "
@@ -380,57 +347,93 @@ msgstr ""
 "Quel disque souhaitez-vous partitionner ? (tapez le nom complet, par exemple "
 "'/dev/sda') : "
 
-#: src/manualpart.py:32
+#: src/manualpart.py:33
 msgid "The chosen target drive doesn't exist."
 msgstr "Le disque cible choisi n'existe pas."
 
-#: src/manualpart.py:39
+#: src/manualpart.py:41
 msgid "Do you want to partition an other drive ? (y/N) : "
 msgstr "Voulez-vous partitionner un autre disque ? (o/N) : "
 
-#: src/manualpart.py:51
+#: src/manualpart.py:54
 msgid "Detected target drive partitions : %s"
 msgstr "Partitions du disque cible détectées : %s"
 
-#: src/manualpart.py:53
+#: src/manualpart.py:56
 msgid "Partition :"
 msgstr "Partition :"
 
-#: src/manualpart.py:57 src/manualpart.py:62
+#: src/manualpart.py:59 src/manualpart.py:64
 msgid "What is the role of this partition ? (%s) : "
 msgstr "Quel est le rôle de cette partition ? (%s) : "
 
-#: src/manualpart.py:58 src/manualpart.py:63
+#: src/manualpart.py:60 src/manualpart.py:65
 msgid "Partition type '%s' is not supported."
 msgstr "Le type de partition '%s' n'est pas supporté."
 
-#: src/manualpart.py:59 src/manualpart.py:64
+#: src/manualpart.py:61 src/manualpart.py:66
 msgid "Supported partition types : "
 msgstr "Types de partition supportés : "
 
-#: src/manualpart.py:68
-msgid "Format the EFI partition ? (Y/n) : "
-msgstr "Formater la partition EFI ? (O/n) : "
+#: src/manualpart.py:70 src/manualpart.py:86 src/manualpart.py:92
+msgid "Format the partition ? (Y/n) : "
+msgstr "Formater la partition ? (O/n) : "
 
-#: src/manualpart.py:83
-msgid "Format the Home partition ? (Y/n) : "
-msgstr "Formater la partition Home ? (O/n) : "
-
-#: src/manualpart.py:93
+#: src/manualpart.py:102
 msgid "What is the mounting point of this partition ? : "
 msgstr "Quel est le point de montage de cette partition ? : "
 
-#: src/manualpart.py:95
+#: src/manualpart.py:104
 msgid "Format the %s partition ? (Y/n) : "
 msgstr "Formater la partition %s ? (O/n) : "
 
-#: src/manualpart.py:99
+#: src/manualpart.py:108
 msgid "The EFI partition is required for system installation."
 msgstr "La partition EFI est nécessaire pour l'installation du système."
 
-#: src/manualpart.py:104
+#: src/manualpart.py:113
 msgid "The Root partition is required for system installation."
 msgstr "La partition Root est nécessaire pour l'installation du système."
+
+#: src/manualpart.py:119
+msgid "The Boot partition is required for system installation."
+msgstr "La partition Boot est nécessaire pour l'installation du système."
+
+#: src/partition.py:80
+msgid "Do you want to encrypt this partition ? (y/N) : "
+msgstr "Voulez-vous chiffrer cette partition ? (o/N) : "
+
+#: src/partition.py:86
+msgid "What will be the encrypted block name ? : "
+msgstr "Quel sera le nom de bloc chiffré ? : "
+
+#: src/partition.py:89
+msgid "Invalid encrypted block name."
+msgstr "Nom de bloc chiffré invalide."
+
+#: src/partition.py:94
+msgid ""
+"Enter the encrypted block password (it will be asked at boot to decrypt the "
+"partition) : "
+msgstr ""
+"Entrez le mot de passe du bloc chiffré (il sera demandé au démarrage pour "
+"déchiffrer la partition) : "
+
+#: src/partition.py:103
+msgid "yes"
+msgstr "oui"
+
+#: src/partition.py:105
+msgid "no"
+msgstr "non"
+
+#: src/partition.py:112
+msgid "%s : %s"
+msgstr "%s : %s"
+
+#: src/partition.py:113
+msgid "%s : %s (mounting point : %s, format %s, format type %s)"
+msgstr "%s : %s (point de montage : %s, formater %s, type de formatage %s)"
 
 #: src/shell.py:20 src/systemsetup.py:40
 msgid "Kernel '%s' is not supported."
@@ -603,61 +606,88 @@ msgstr ""
 msgid "Package %s doesn't exist."
 msgstr "Le paquet %s n'existe pas."
 
-#: src/systemsetup.py:132
-msgid "Your hostname : %s"
-msgstr "Votre nom d'hôte : %s"
-
-#: src/systemsetup.py:139
-msgid "Your timezone : %s"
-msgstr "Votre fuseau horaire : %s"
-
-#: src/systemsetup.py:141
-msgid "Additional user name : %s"
-msgstr "Nom d'utilisateur supplémentaire : %s"
-
-#: src/systemsetup.py:143
-msgid "User's full name : %s"
-msgstr "Nom complet de l'utilisateur : %s"
-
-#: src/systemsetup.py:145
-msgid "More packages to install : %s"
-msgstr "Plus de paquets à installer : %s"
-
-#: src/utils.py:87
-msgid "Format type '%s' is not supported."
-msgstr "Le type de formatage '%s' n'est pas supporté."
-
-#: src/utils.py:87
-msgid "Which format type do you want ? (%s) : "
-msgstr "Quel type de formatage voulez-vous ? (%s) : "
-
-#: src/utils.py:88
-msgid "Supported format types : "
-msgstr "Types de formatage supportés : "
-
-#: src/utils.py:100
+#: src/systemsetup.py:124 src/systemsetup.py:127
 msgid "%s password configuration : "
 msgstr "Configuration du mot de passe de %s : "
 
-#: src/utils.py:101
+#: src/systemsetup.py:125 src/systemsetup.py:128
 msgid "Enter the %s password : "
 msgstr "Entrez le mot de passe de %s : "
 
-#: src/utils.py:102
-msgid "Re-enter the %s password to confirm : "
-msgstr "Saisissez à nouveau le mot de passe de %s pour confirmer : "
+#: src/systemsetup.py:134
+msgid "Your hostname : %s"
+msgstr "Votre nom d'hôte : %s"
 
-#: src/utils.py:104
+#: src/systemsetup.py:141
+msgid "Your timezone : %s"
+msgstr "Votre fuseau horaire : %s"
+
+#: src/systemsetup.py:143
+msgid "Additional user name : %s"
+msgstr "Nom d'utilisateur supplémentaire : %s"
+
+#: src/systemsetup.py:145
+msgid "User's full name : %s"
+msgstr "Nom complet de l'utilisateur : %s"
+
+#: src/systemsetup.py:147
+msgid "More packages to install : %s"
+msgstr "Plus de paquets à installer : %s"
+
+#: src/utils.py:55
+msgid "Format type '%s' is not supported."
+msgstr "Le type de formatage '%s' n'est pas supporté."
+
+#: src/utils.py:55
+msgid "Which format type do you want ? (%s) : "
+msgstr "Quel type de formatage voulez-vous ? (%s) : "
+
+#: src/utils.py:56
+msgid "Supported format types : "
+msgstr "Types de formatage supportés : "
+
+#: src/utils.py:70
+msgid "Enter it again to confirm : "
+msgstr "Saisissez le à nouveau pour confirmer : "
+
+#: src/utils.py:72
 msgid "Passwords entered don't match."
 msgstr "Les mots de passe saisis ne correspondent pas."
 
-#: src/utils.py:178
+#: src/utils.py:124
 msgid "Help :"
 msgstr "Aide :"
 
-#: src/utils.py:302
+#: src/utils.py:163
+msgid "The input must not be empty."
+msgstr "La saisie ne doit pas être vide."
+
+#: src/utils.py:268
 msgid "Press any key to continue..."
 msgstr "Appuyez sur n'importe quelle touche pour continuer..."
+
+#~ msgid "ROOT partition : %s (mounting point : %s, format type %s)"
+#~ msgstr "Partition ROOT : %s (point de montage : %s, type de formatage %s)"
+
+#~ msgid "Home partition : %s (mounting point : %s, format %s, format type %s)"
+#~ msgstr ""
+#~ "Partition Home : %s (point de montage : %s, formater %s, type de "
+#~ "formatage %s)"
+
+#~ msgid "Swap partition : %s"
+#~ msgstr "Partition Swap : %s"
+
+#~ msgid ""
+#~ "Other partition : %s (mounting point : %s, format %s, format type %s)"
+#~ msgstr ""
+#~ "Autre partition : %s (point de montage : %s, formater %s, type de "
+#~ "formatage %s)"
+
+#~ msgid "Format the EFI partition ? (Y/n) : "
+#~ msgstr "Formater la partition EFI ? (O/n) : "
+
+#~ msgid "Format the Home partition ? (Y/n) : "
+#~ msgstr "Formater la partition Home ? (O/n) : "
 
 #, fuzzy
 #~| msgid "Install GDM."

--- a/src/archcraftsman.py
+++ b/src/archcraftsman.py
@@ -42,7 +42,7 @@ from src.shell import shell
 from src.utils import print_error, execute, stdout, print_step, print_sub_step
 
 
-def pre_launch_steps() -> {}:
+def pre_launch_steps() -> dict[str, any]:
     """
     The method to proceed to the pre-launch steps
     :return:
@@ -69,7 +69,7 @@ def pre_launch_steps() -> {}:
     return pre_launch_info
 
 
-def pre_launch() -> {}:
+def pre_launch() -> dict[str, any]:
     """
     A pre-launch steps method.
     :return:

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -123,6 +123,18 @@ def auto_partitioning() -> PartitioningInfo or None:
             partitioning_info.partitions.append(
                 Partition(index=index, part_type=PartTypes.SWAP, compute=False))
             index += 1
+        if root_block_name:
+            # BOOT
+            auto_part_str += "n\n"  # Add a new partition
+            if is_bios():
+                auto_part_str += "p\n"  # Partition primary (Accept default: primary)
+            auto_part_str += " \n"  # Partition number (Accept default: auto)
+            auto_part_str += " \n"  # First sector (Accept default: 1)
+            auto_part_str += f'+2G\n'  # Last sector (Accept default: varies)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.BOOT, part_mount_point="/boot", part_format=True,
+                          part_format_type=part_format_type, compute=False))
+            index += 1
         if want_home:
             # ROOT
             auto_part_str += "n\n"  # Add a new partition

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -9,7 +9,7 @@ from src.options import SwapTypes, PartTypes, FSFormats
 from src.partition import Partition
 from src.partitioninginfo import PartitioningInfo
 from src.utils import ask_format_type, is_bios, from_iec, to_iec, print_error, print_step, print_sub_step, prompt, \
-    prompt_bool, prompt_option, execute, ask_encryption_credentials
+    prompt_bool, prompt_option, execute, ask_encryption_block_name
 
 _ = I18n().gettext
 
@@ -50,14 +50,12 @@ def auto_partitioning() -> PartitioningInfo or None:
         want_home = prompt_bool(_("Do you want a separated Home ? (Y/n) : "))
         part_format_type = ask_format_type()
         root_block_name = None
-        root_block_password = None
         if prompt_bool(_("Do you want to encrypt the %s partition ? (y/N) : ") % "Root", default=False):
-            root_block_name, root_block_password = ask_encryption_credentials()
+            root_block_name = ask_encryption_block_name()
         home_block_name = None
-        home_block_password = None
         if want_home:
             if prompt_bool(_("Do you want to encrypt the %s partition ? (y/N) : ") % "Home", default=False):
-                home_block_name, home_block_password = ask_encryption_credentials()
+                home_block_name = ask_encryption_block_name()
 
         if want_dual_boot:
             root_size = to_iec(int(disk.free_space / 4))
@@ -174,16 +172,12 @@ def auto_partitioning() -> PartitioningInfo or None:
         auto_part_str += "w\n"
 
         for partition in partitioning_info.partitions:
-            if partition.part_type == PartTypes.ROOT \
-                    and root_block_name is not None and root_block_password is not None:
+            if partition.part_type == PartTypes.ROOT and root_block_name is not None:
                 partition.encrypted = True
                 partition.block_name = root_block_name
-                partition.block_password = root_block_password
-            if partition.part_type == PartTypes.HOME \
-                    and home_block_name is not None and home_block_password is not None:
+            if partition.part_type == PartTypes.HOME and home_block_name is not None:
                 partition.encrypted = True
                 partition.block_name = home_block_name
-                partition.block_password = home_block_password
 
         print_step(_("Summary of choices :"))
         for partition in partitioning_info.partitions:

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -130,7 +130,7 @@ def auto_partitioning() -> PartitioningInfo or None:
                 auto_part_str += "p\n"  # Partition primary (Accept default: primary)
             auto_part_str += " \n"  # Partition number (Accept default: auto)
             auto_part_str += " \n"  # First sector (Accept default: 1)
-            auto_part_str += f'+2G\n'  # Last sector (Accept default: varies)
+            auto_part_str += "+2G\n"  # Last sector (Accept default: varies)
             partitioning_info.partitions.append(
                 Partition(index=index, part_type=PartTypes.BOOT, part_mount_point="/boot", part_format=True,
                           part_format_type=part_format_type, compute=False))

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -6,21 +6,20 @@ import os
 from src.disk import Disk
 from src.i18n import I18n
 from src.options import SwapTypes, PartTypes, FSFormats
-from src.utils import ask_format_type, is_bios, from_iec, to_iec, \
-    build_partition_name, print_error, print_step, print_sub_step, prompt, prompt_bool, prompt_option, execute
+from src.partition import Partition
+from src.partitioninginfo import PartitioningInfo
+from src.utils import ask_format_type, is_bios, from_iec, to_iec, print_error, print_step, print_sub_step, prompt, \
+    prompt_bool, prompt_option, execute
 
 _ = I18n().gettext
 
 
-def auto_partitioning() -> {}:
+def auto_partitioning() -> PartitioningInfo or None:
     """
     The method to proceed to the automatic partitioning.
     :return:
     """
-    partitioning_info_by_index = {"indexes": set(), "part_type": {}, "part_mount_point": {}, "part_format": {},
-                                  "part_format_type": {}}
-    partitioning_info = {"partitions": [], "part_type": {}, "part_mount_point": {}, "part_format": {},
-                         "part_format_type": {}, "root_partition": None, "swapfile_size": None, "main_disk": None}
+    partitioning_info = PartitioningInfo()
     user_answer = False
     while not user_answer:
         print_step(_("Automatic partitioning :"))
@@ -33,7 +32,7 @@ def auto_partitioning() -> {}:
         if not os.path.exists(target_disk):
             print_error(_("You need to choose a target drive."))
             continue
-        partitioning_info["main_disk"] = target_disk
+        partitioning_info.main_disk = target_disk
         disk = Disk(target_disk)
         efi_partition = disk.get_efi_partition()
         if not is_bios() \
@@ -59,7 +58,7 @@ def auto_partitioning() -> {}:
         if swap_type == SwapTypes.NONE:
             swap_size = None
         elif swap_type == SwapTypes.FILE:
-            partitioning_info["swapfile_size"] = swap_size
+            partitioning_info.swapfile_size = swap_size
         auto_part_str = ""
         index = 0
         if is_bios():
@@ -72,11 +71,9 @@ def auto_partitioning() -> {}:
             auto_part_str += " \n"  # First sector (Accept default: 1)
             auto_part_str += "+1G\n"  # Last sector (Accept default: varies)
             auto_part_str += "a\n"  # Toggle bootable flag
-            partitioning_info_by_index["part_type"][index] = PartTypes.OTHER
-            partitioning_info_by_index["part_mount_point"][index] = "/boot"
-            partitioning_info_by_index["part_format"][index] = True
-            partitioning_info_by_index["part_format_type"][index] = part_format_type
-            partitioning_info_by_index["indexes"].add(index)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.OTHER, part_mount_point="/boot", part_format=True,
+                          part_format_type=part_format_type, compute=False))
             index += 1
         else:
             if not want_dual_boot:
@@ -90,17 +87,14 @@ def auto_partitioning() -> {}:
                 auto_part_str += "t\n"  # Change partition type
                 auto_part_str += " \n"  # Partition number (Accept default: auto)
                 auto_part_str += "1\n"  # Type EFI System
-                partitioning_info_by_index["part_format"][index] = True
-                partitioning_info_by_index["part_format_type"][index] = FSFormats.VFAT
-                partitioning_info_by_index["part_type"][index] = PartTypes.EFI
-                partitioning_info_by_index["part_mount_point"][index] = "/boot/efi"
-                partitioning_info_by_index["indexes"].add(index)
+                partitioning_info.partitions.append(
+                    Partition(index=index, part_type=PartTypes.EFI, part_mount_point="/boot/efi", part_format=True,
+                              part_format_type=FSFormats.VFAT, compute=False))
                 index += 1
             else:
-                partitioning_info_by_index["part_format"][efi_partition.index] = False
-                partitioning_info_by_index["part_type"][efi_partition.index] = PartTypes.EFI
-                partitioning_info_by_index["part_mount_point"][efi_partition.index] = "/boot/efi"
-                partitioning_info_by_index["indexes"].add(efi_partition.index)
+                partitioning_info.partitions.append(
+                    Partition(index=index, part_type=PartTypes.EFI, part_mount_point="/boot/efi", part_format=False,
+                              compute=False))
                 index += len(disk.partitions)
         if swap_type == SwapTypes.PARTITION:
             # SWAP
@@ -116,8 +110,8 @@ def auto_partitioning() -> {}:
                 auto_part_str += "82\n"  # Type Linux Swap
             else:
                 auto_part_str += "19\n"  # Type Linux Swap
-            partitioning_info_by_index["part_type"][index] = PartTypes.SWAP
-            partitioning_info_by_index["indexes"].add(index)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.SWAP, compute=False))
             index += 1
         if want_home:
             # ROOT
@@ -127,10 +121,9 @@ def auto_partitioning() -> {}:
             auto_part_str += " \n"  # Partition number (Accept default: auto)
             auto_part_str += " \n"  # First sector (Accept default: 1)
             auto_part_str += f'+{root_size}\n'  # Last sector (Accept default: varies)
-            partitioning_info_by_index["part_type"][index] = PartTypes.ROOT
-            partitioning_info_by_index["part_mount_point"][index] = "/"
-            partitioning_info_by_index["part_format_type"][index] = part_format_type
-            partitioning_info_by_index["indexes"].add(index)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.ROOT, part_mount_point="/", part_format=True,
+                          part_format_type=part_format_type, compute=False))
             index += 1
             # HOME
             auto_part_str += "n\n"  # Add a new partition
@@ -139,11 +132,9 @@ def auto_partitioning() -> {}:
             auto_part_str += " \n"  # Partition number (Accept default: auto)
             auto_part_str += " \n"  # First sector (Accept default: 1)
             auto_part_str += " \n"  # Last sector (Accept default: varies)
-            partitioning_info_by_index["part_type"][index] = PartTypes.HOME
-            partitioning_info_by_index["part_mount_point"][index] = "/home"
-            partitioning_info_by_index["part_format"][index] = True
-            partitioning_info_by_index["part_format_type"][index] = part_format_type
-            partitioning_info_by_index["indexes"].add(index)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.HOME, part_mount_point="/home", part_format=True,
+                          part_format_type=part_format_type, compute=False))
             index += 1
         else:
             # ROOT
@@ -153,63 +144,35 @@ def auto_partitioning() -> {}:
             auto_part_str += " \n"  # Partition number (Accept default: auto)
             auto_part_str += " \n"  # First sector (Accept default: 1)
             auto_part_str += " \n"  # Last sector (Accept default: varies)
-            partitioning_info_by_index["part_type"][index] = PartTypes.ROOT
-            partitioning_info_by_index["part_mount_point"][index] = "/"
-            partitioning_info_by_index["part_format_type"][index] = part_format_type
-            partitioning_info_by_index["indexes"].add(index)
+            partitioning_info.partitions.append(
+                Partition(index=index, part_type=PartTypes.ROOT, part_mount_point="/", part_format=True,
+                          part_format_type=part_format_type, compute=False))
             index += 1
         # WRITE
         auto_part_str += "w\n"
 
         print_step(_("Summary of choices :"), clear=False)
-        for index in partitioning_info_by_index["indexes"]:
-            if partitioning_info_by_index["part_format"].get(index):
-                formatting = _("yes")
-            else:
-                formatting = _("no")
-            if partitioning_info_by_index["part_type"].get(index) == PartTypes.EFI:
-                print_sub_step(_("EFI partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (index + 1, partitioning_info_by_index["part_mount_point"].get(index), formatting,
-                                  partitioning_info_by_index["part_format_type"].get(index)))
-            if partitioning_info_by_index["part_type"].get(index) == PartTypes.ROOT:
-                print_sub_step(_("ROOT partition : %s (mounting point : %s, format type %s)")
-                               % (index + 1, partitioning_info_by_index["part_mount_point"].get(index),
-                                  partitioning_info_by_index["part_format_type"].get(index)))
-            if partitioning_info_by_index["part_type"].get(index) == PartTypes.HOME:
-                print_sub_step(_("Home partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (index + 1, partitioning_info_by_index["part_mount_point"].get(index), formatting,
-                                  partitioning_info_by_index["part_format_type"].get(index)))
-            if partitioning_info_by_index["part_type"].get(index) == PartTypes.SWAP:
-                print_sub_step(_("Swap partition : %s") % (index + 1))
-            if partitioning_info_by_index["part_type"].get(index) == PartTypes.OTHER:
-                print_sub_step(_("Other partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (index + 1, partitioning_info_by_index["part_mount_point"].get(index), formatting,
-                                  partitioning_info_by_index["part_format_type"].get(index)))
-        if "SWAP" not in partitioning_info_by_index["part_type"].values() and swap_size:
+        for partition in partitioning_info.partitions:
+            print_sub_step(partition.summary())
+        if "SWAP" not in [part.part_type for part in partitioning_info.partitions] and swap_size:
             print_sub_step(_("Swapfile size : %s") % swap_size)
         user_answer = prompt_bool(_("Is the informations correct ? (y/N) : "), default=False)
         if not user_answer:
             want_to_change = prompt_bool(_("Do you want to change the partitioning mode ? (y/N) : "), default=False)
             if want_to_change:
                 return None
-            partitioning_info_by_index["indexes"].clear()
+            partitioning_info.partitions.clear()
         else:
             execute(f'echo -e "{auto_part_str}" | fdisk "{target_disk}" &>/dev/null')
 
-            for index in partitioning_info_by_index["indexes"]:
-                partition = build_partition_name(target_disk, index)
+            for partition in partitioning_info.partitions:
+                partition.build_partition_name(target_disk)
+                partition.compute()
 
-                partitioning_info["part_type"][partition] = partitioning_info_by_index["part_type"].get(index)
-                partitioning_info["part_mount_point"][partition] = partitioning_info_by_index["part_mount_point"].get(
-                    index)
-                partitioning_info["part_format_type"][partition] = partitioning_info_by_index["part_format_type"].get(
-                    index)
-                partitioning_info["part_format"][partition] = partitioning_info_by_index["part_format"].get(index)
+                if partition.part_type == PartTypes.ROOT:
+                    partitioning_info.root_partition = partition
 
-                if partitioning_info_by_index["part_type"].get(index) == PartTypes.ROOT:
-                    partitioning_info["root_partition"] = partition
-
-                if partition not in partitioning_info["partitions"]:
-                    partitioning_info["partitions"].append(partition)
+                if partition not in partitioning_info.partitions:
+                    partitioning_info.partitions.append(partition)
 
     return partitioning_info

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -9,7 +9,7 @@ from src.options import SwapTypes, PartTypes, FSFormats
 from src.partition import Partition
 from src.partitioninginfo import PartitioningInfo
 from src.utils import ask_format_type, is_bios, from_iec, to_iec, print_error, print_step, print_sub_step, prompt, \
-    prompt_bool, prompt_option, execute, ask_encryption_block_name
+    prompt_bool, prompt_option, execute
 
 _ = I18n().gettext
 
@@ -51,11 +51,11 @@ def auto_partitioning() -> PartitioningInfo or None:
         part_format_type = ask_format_type()
         root_block_name = None
         if prompt_bool(_("Do you want to encrypt the %s partition ? (y/N) : ") % "Root", default=False):
-            root_block_name = ask_encryption_block_name()
+            root_block_name = "root"
         home_block_name = None
         if want_home:
             if prompt_bool(_("Do you want to encrypt the %s partition ? (y/N) : ") % "Home", default=False):
-                home_block_name = ask_encryption_block_name()
+                home_block_name = "home"
 
         if want_dual_boot:
             root_size = to_iec(int(disk.free_space / 4))

--- a/src/autopart.py
+++ b/src/autopart.py
@@ -195,7 +195,6 @@ def auto_partitioning() -> PartitioningInfo or None:
 
             for partition in partitioning_info.partitions:
                 partition.build_partition_name(target_disk)
-                partition.compute()
 
                 if partition.part_type == PartTypes.ROOT:
                     partitioning_info.root_partition = partition

--- a/src/bundles/budgie.py
+++ b/src/bundles/budgie.py
@@ -17,7 +17,7 @@ class Budgie(Bundle):
     """
     display_manager = True
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["budgie-desktop", "budgie-desktop-view", "budgie-screensaver", "gnome-control-center",
                     "network-manager-applet", "gnome-terminal", "nautilus", "xorg-server", "alsa-utils", "pulseaudio",
                     "pulseaudio-alsa", "pavucontrol", "arc-gtk-theme", "arc-icon-theme"]

--- a/src/bundles/budgie.py
+++ b/src/bundles/budgie.py
@@ -5,6 +5,7 @@ The budgie bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -33,7 +34,7 @@ class Budgie(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % ("LightDM" if self.display_manager else _("none")))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable lightdm"')
         if "fr" in pre_launch_info["keymap"]:

--- a/src/bundles/bundle.py
+++ b/src/bundles/bundle.py
@@ -14,7 +14,7 @@ class Bundle:
     def __init__(self, name: OptionEnum):
         self.name = name
 
-    def packages(self, system_info: {}) -> [str]:  # pylint: disable=unused-argument
+    def packages(self, system_info: dict[str, any]) -> list[str]:  # pylint: disable=unused-argument
         """
         Bundle's packages retrieving method.
         """

--- a/src/bundles/bundle.py
+++ b/src/bundles/bundle.py
@@ -2,6 +2,7 @@
 The generic bundle blueprint module
 """
 from src.options import OptionEnum
+from src.partitioninginfo import PartitioningInfo
 
 
 class Bundle:
@@ -29,7 +30,7 @@ class Bundle:
         Bundle's print resume method.
         """
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         """
         Bundle configuration method.
         :param system_info:

--- a/src/bundles/cinnamon.py
+++ b/src/bundles/cinnamon.py
@@ -17,7 +17,7 @@ class Cinnamon(Bundle):
     """
     display_manager = True
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["cinnamon", "metacity", "gnome-shell", "gnome-terminal", "blueberry", "cinnamon-translations",
                     "gnome-panel", "system-config-printer", "wget", "xorg-server", "alsa-utils", "pulseaudio",
                     "pulseaudio-alsa", "pavucontrol"]

--- a/src/bundles/cinnamon.py
+++ b/src/bundles/cinnamon.py
@@ -5,6 +5,7 @@ The cinnamon bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -33,7 +34,7 @@ class Cinnamon(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % ("LightDM" if self.display_manager else _("none")))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable lightdm"')
         execute(

--- a/src/bundles/copyacm.py
+++ b/src/bundles/copyacm.py
@@ -3,6 +3,7 @@ The copy ArchCraftsman bundle module
 """
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -16,7 +17,7 @@ class CopyACM(Bundle):
     def print_resume(self):
         print_sub_step(_("Copy ArchCraftsman to the new system."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         username = system_info["user_name"]
         if username != "":
             path = f'/home/{username}/ArchCraftsman'

--- a/src/bundles/cups.py
+++ b/src/bundles/cups.py
@@ -15,7 +15,7 @@ class Cups(Bundle):
     Cups class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["cups", "cups-pdf", "avahi", "samba", "foomatic-db-engine", "foomatic-db", "foomatic-db-ppds",
                 "foomatic-db-nonfree-ppds", "foomatic-db-gutenprint-ppds", "gutenprint", "ghostscript"]
 

--- a/src/bundles/cups.py
+++ b/src/bundles/cups.py
@@ -4,6 +4,7 @@ The cups bundle module
 
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -21,7 +22,7 @@ class Cups(Bundle):
     def print_resume(self):
         print_sub_step(_("Install Cups."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable avahi-daemon"')
         execute('arch-chroot /mnt bash -c "systemctl enable cups"')
         execute('arch-chroot /mnt bash -c "systemctl enable cups-browsed"')

--- a/src/bundles/cutefish.py
+++ b/src/bundles/cutefish.py
@@ -17,7 +17,7 @@ class Cutefish(Bundle):
     """
     display_manager = True
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["cutefish", "xorg-server", "alsa-utils", "pulseaudio", "pulseaudio-alsa", "pavucontrol"]
         if self.display_manager:
             packages.extend(["sddm"])

--- a/src/bundles/cutefish.py
+++ b/src/bundles/cutefish.py
@@ -5,6 +5,7 @@ The cutefish bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -31,7 +32,7 @@ class Cutefish(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % ("SDDM" if self.display_manager else _("none")))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable sddm"')
         if "fr" in pre_launch_info["keymap"]:

--- a/src/bundles/deepin.py
+++ b/src/bundles/deepin.py
@@ -17,7 +17,7 @@ class Deepin(Bundle):
     """
     minimal = False
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["deepin", "xorg-server", "alsa-utils", "pulseaudio", "pulseaudio-alsa"]
         if self.minimal is not True:
             packages.append("deepin-extra")

--- a/src/bundles/deepin.py
+++ b/src/bundles/deepin.py
@@ -5,6 +5,7 @@ The deepin bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -34,7 +35,7 @@ class Deepin(Bundle):
             default=False,
             help_msg=_("If yes, the script will not install any extra packages, only base packages."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable lightdm"')
         execute(
             'sed -i "s|#logind-check-graphical=false|logind-check-graphical=true|g" /mnt/etc/lightdm/lightdm.conf')

--- a/src/bundles/enlightenment.py
+++ b/src/bundles/enlightenment.py
@@ -5,6 +5,7 @@ The enlightenment bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -24,7 +25,7 @@ class Enlightenment(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % _("none"))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable acpid"')
         if "fr" in pre_launch_info["keymap"]:
             setup_chroot_keyboard("fr")

--- a/src/bundles/enlightenment.py
+++ b/src/bundles/enlightenment.py
@@ -16,7 +16,7 @@ class Enlightenment(Bundle):
     Bundle class.
     """
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["enlightenment", "terminology", "xorg-server", "xorg-xinit", "alsa-utils", "pulseaudio",
                     "pulseaudio-alsa", "pavucontrol", "system-config-printer", "network-manager-applet", "acpid"]
         return packages

--- a/src/bundles/gnome.py
+++ b/src/bundles/gnome.py
@@ -17,7 +17,7 @@ class Gnome(Bundle):
     """
     minimal = False
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["gnome", "alsa-utils", "pulseaudio", "pulseaudio-alsa", "xdg-desktop-portal",
                     "xdg-desktop-portal-gnome", "qt5-wayland"]
         if self.minimal is not True:

--- a/src/bundles/gnome.py
+++ b/src/bundles/gnome.py
@@ -5,6 +5,7 @@ The gnome bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -33,7 +34,7 @@ class Gnome(Bundle):
             default=False,
             help_msg=_("If yes, the script will not install any extra packages, only base packages."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable gdm"')
         if "fr" in pre_launch_info["keymap"]:
             setup_chroot_keyboard("fr")

--- a/src/bundles/grmlzsh.py
+++ b/src/bundles/grmlzsh.py
@@ -4,6 +4,7 @@ The grml zsh bundle module
 
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -20,6 +21,6 @@ class GrmlZsh(Bundle):
     def print_resume(self):
         print_sub_step(_("Install ZSH with GRML configuration."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "chsh --shell /bin/zsh"')
         execute(f'arch-chroot /mnt bash -c "chsh --shell /bin/zsh {system_info["user_name"]}"')

--- a/src/bundles/grmlzsh.py
+++ b/src/bundles/grmlzsh.py
@@ -15,7 +15,7 @@ class GrmlZsh(Bundle):
     Grml ZSH config class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["zsh", "zsh-completions", "grml-zsh-config"]
 
     def print_resume(self):

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -52,8 +52,10 @@ class Grub(Bundle):
                 extracted_grub_cmdline = grub_cmdline_match.group(1).split(" ")
             else:
                 extracted_grub_cmdline = []
-            extracted_grub_cmdline.append(
-                f"cryptdevice=UUID={partitioning_info.root_partition.uuid}:root root=/dev/mapper/root")
+            for partition in [part for part in partitioning_info.partitions if part.encrypted]:
+                extracted_grub_cmdline.append(
+                    f"cryptdevice=UUID={partition.uuid}:{partition.block_name} "
+                    f"{partition.block_name}={partition.real_path()}")
             processed_grub_cmdline = f"GRUB_CMDLINE_LINUX_DEFAULT=\"{' '.join(extracted_grub_cmdline)}\""
             execute(f'sed -i \'s|{grub_cmdline}|{processed_grub_cmdline}|g\' /mnt/etc/default/grub')
 

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -4,6 +4,7 @@ The grub bundle module
 
 from src.bundles.bundle import Bundle
 from src.options import FSFormats
+from src.partitioninginfo import PartitioningInfo
 from src.utils import is_bios, execute
 
 
@@ -15,15 +16,15 @@ class Grub(Bundle):
     def packages(self, system_info) -> [str]:
         return ["grub"]
 
-    def configure(self, system_info: dict, pre_launch_info: dict, partitioning_info: dict):
+    def configure(self, system_info: dict, pre_launch_info: dict, partitioning_info: PartitioningInfo):
         if is_bios():
-            execute(f'arch-chroot /mnt bash -c "grub-install --target=i386-pc {partitioning_info["main_disk"]}"')
+            execute(f'arch-chroot /mnt bash -c "grub-install --target=i386-pc {partitioning_info.main_disk}"')
         else:
             execute(
                 'arch-chroot /mnt bash -c "grub-install --target=x86_64-efi --efi-directory=/boot/efi '
                 '--bootloader-id=\'Arch Linux\'"')
         execute('sed -i "/^GRUB_CMDLINE_LINUX=.*/a GRUB_DISABLE_OS_PROBER=false" /mnt/etc/default/grub')
-        if partitioning_info["part_format_type"][partitioning_info["root_partition"]] in {FSFormats.EXT4}:
+        if partitioning_info.root_partition.part_format_type == FSFormats.EXT4:
             execute('sed -i "s|GRUB_DEFAULT=.*|GRUB_DEFAULT=saved|g" /mnt/etc/default/grub')
             execute('sed -i "/^GRUB_DEFAULT=.*/a GRUB_SAVEDEFAULT=true" /mnt/etc/default/grub')
         execute('arch-chroot /mnt bash -c "grub-mkconfig -o /boot/grub/grub.cfg"')

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -53,9 +53,8 @@ class Grub(Bundle):
             else:
                 extracted_grub_cmdline = []
             for partition in [part for part in partitioning_info.partitions if part.encrypted]:
-                extracted_grub_cmdline.append(
-                    f"cryptdevice=UUID={partition.uuid}:{partition.block_name} "
-                    f"{partition.block_name}={partition.real_path()}")
+                extracted_grub_cmdline.append(f"cryptdevice=UUID={partition.uuid}:{partition.block_name}")
+            extracted_grub_cmdline.append(f"root={partitioning_info.root_partition.real_path()}")
             processed_grub_cmdline = f"GRUB_CMDLINE_LINUX_DEFAULT=\"{' '.join(extracted_grub_cmdline)}\""
             execute(f'sed -i \'s|{grub_cmdline}|{processed_grub_cmdline}|g\' /mnt/etc/default/grub')
 

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -13,7 +13,7 @@ class Grub(Bundle):
     The Grub Bootloader class.
     """
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         return ["grub"]
 
     def configure(self, system_info: dict, pre_launch_info: dict, partitioning_info: PartitioningInfo):

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -34,9 +34,9 @@ class Grub(Bundle):
             hooks_match = pattern.search(hooks)
             if hooks_match:
                 extracted_hooks = hooks_match.group(1).split(" ")
-                extracted_hooks.insert(extracted_hooks.index("filesystems"), "encrypted")
+                extracted_hooks.insert(extracted_hooks.index("filesystems"), "encrypt")
             else:
-                extracted_hooks = ["encrypted"]
+                extracted_hooks = ["encrypt"]
             processed_hooks = f"HOOKS=({' '.join(extracted_hooks)})"
             execute(f'sed -i "s|{hooks}|{processed_hooks}|g" /mnt/etc/mkinitcpio.conf')
             execute('arch-chroot /mnt bash -c "mkinitcpio -P"')

--- a/src/bundles/grub.py
+++ b/src/bundles/grub.py
@@ -38,7 +38,7 @@ class Grub(Bundle):
             else:
                 extracted_hooks = ["encrypt"]
             processed_hooks = f"HOOKS=({' '.join(extracted_hooks)})"
-            execute(f'sed -i "s|{hooks}|{processed_hooks}|g" /mnt/etc/mkinitcpio.conf')
+            execute(f'sed -i \'s|{hooks}|{processed_hooks}|g\' /mnt/etc/mkinitcpio.conf')
             execute('arch-chroot /mnt bash -c "mkinitcpio -P"')
 
         if partitioning_info.root_partition.encrypted:
@@ -55,7 +55,7 @@ class Grub(Bundle):
             extracted_grub_cmdline.append(
                 f"cryptdevice=UUID={partitioning_info.root_partition.uuid}:root root=/dev/mapper/root")
             processed_grub_cmdline = f"GRUB_CMDLINE_LINUX_DEFAULT=\"{' '.join(extracted_grub_cmdline)}\""
-            execute(f'sed -i "s|{grub_cmdline}|{processed_grub_cmdline}|g" /mnt/etc/default/grub')
+            execute(f'sed -i \'s|{grub_cmdline}|{processed_grub_cmdline}|g\' /mnt/etc/default/grub')
 
         if partitioning_info.root_partition.part_format_type == FSFormats.EXT4:
             execute('sed -i "s|GRUB_DEFAULT=.*|GRUB_DEFAULT=saved|g" /mnt/etc/default/grub')

--- a/src/bundles/i3.py
+++ b/src/bundles/i3.py
@@ -16,7 +16,7 @@ class I3(Bundle):
     Bundle class.
     """
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["i3", "rofi", "dmenu", "perl", "alacritty", "xorg-server", "xorg-xinit", "alsa-utils", "pulseaudio",
                     "pulseaudio-alsa", "pavucontrol", "system-config-printer", "network-manager-applet", "acpid",
                     "gnome-keyring", "dex"]

--- a/src/bundles/i3.py
+++ b/src/bundles/i3.py
@@ -5,6 +5,7 @@ The i3 bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -25,7 +26,7 @@ class I3(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % _("none"))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable acpid"')
         if "fr" in pre_launch_info["keymap"]:
             setup_chroot_keyboard("fr")

--- a/src/bundles/linux.py
+++ b/src/bundles/linux.py
@@ -14,7 +14,7 @@ class LinuxCurrent(bundle.Bundle):
     The Linux current kernel class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["linux", "linux-headers"]
 
     def print_resume(self):
@@ -26,7 +26,7 @@ class LinuxHardened(Bundle):
     The Linux hardened kernel class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["linux-hardened", "linux-hardened-headers"]
 
     def print_resume(self):
@@ -38,7 +38,7 @@ class LinuxLts(bundle.Bundle):
     The Linux LTS kernel class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["linux-lts", "linux-lts-headers"]
 
     def print_resume(self):
@@ -50,7 +50,7 @@ class LinuxZen(bundle.Bundle):
     The Linux zen kernel class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["linux-zen", "linux-zen-headers"]
 
     def print_resume(self):

--- a/src/bundles/lxqt.py
+++ b/src/bundles/lxqt.py
@@ -17,7 +17,7 @@ class Lxqt(Bundle):
     """
     display_manager = True
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["lxqt", "xorg-server", "breeze-icons", "xdg-utils", "xscreensaver", "xautolock", "libpulse",
                     "alsa-lib", "libstatgrab", "libsysstat", "lm_sensors", "system-config-printer", "alsa-utils",
                     "pulseaudio", "pulseaudio-alsa", "pavucontrol", "network-manager-applet"]

--- a/src/bundles/lxqt.py
+++ b/src/bundles/lxqt.py
@@ -5,6 +5,7 @@ The lxqt bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -33,7 +34,7 @@ class Lxqt(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % ("SDDM" if self.display_manager else _("none")))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable sddm"')
         if "fr" in pre_launch_info["keymap"]:

--- a/src/bundles/mainfilesystems.py
+++ b/src/bundles/mainfilesystems.py
@@ -8,7 +8,7 @@ from src.utils import print_sub_step
 _ = I18n().gettext
 
 
-def get_main_file_systems() -> [str]:
+def get_main_file_systems() -> list[str]:
     """
     The method to get the package list of the main file systems group.
     :return:
@@ -22,7 +22,7 @@ class MainFileSystems(Bundle):
     The main file systems class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return get_main_file_systems()
 
     def print_resume(self):

--- a/src/bundles/mainfonts.py
+++ b/src/bundles/mainfonts.py
@@ -8,7 +8,7 @@ from src.utils import print_sub_step
 _ = I18n().gettext
 
 
-def get_main_fonts() -> [str]:
+def get_main_fonts() -> list[str]:
     """
     The method to get the package list of the main fonts group.
     :return:
@@ -25,7 +25,7 @@ class MainFonts(Bundle):
     The main fonts class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return get_main_fonts()
 
     def print_resume(self):

--- a/src/bundles/mate.py
+++ b/src/bundles/mate.py
@@ -5,6 +5,7 @@ The mate bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -40,7 +41,7 @@ class Mate(Bundle):
             default=False,
             help_msg=_("If yes, the script will not install any extra packages, only base packages."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable lightdm"')
         execute(

--- a/src/bundles/mate.py
+++ b/src/bundles/mate.py
@@ -18,7 +18,7 @@ class Mate(Bundle):
     display_manager = True
     minimal = False
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["mate", "xorg-server", "alsa-utils", "pulseaudio", "pulseaudio-alsa", "network-manager-applet"]
         if self.display_manager:
             packages.extend(["lightdm", "lightdm-gtk-greeter", "lightdm-gtk-greeter-settings"])

--- a/src/bundles/microcodes.py
+++ b/src/bundles/microcodes.py
@@ -24,7 +24,7 @@ class Microcodes(Bundle):
         else:
             self.microcode_name = None
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         if self.microcode_name == "GenuineIntel":
             return ["intel-ucode"]
         if self.microcode_name == "AuthenticAMD":

--- a/src/bundles/nvidia.py
+++ b/src/bundles/nvidia.py
@@ -14,7 +14,7 @@ class NvidiaDriver(Bundle):
     The Nvidia driver class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         if "kernel" in system_info and system_info["kernel"] and system_info["kernel"].name == Kernels.LTS:
             return ["nvidia-lts"]
         return ["nvidia"]

--- a/src/bundles/pipewire.py
+++ b/src/bundles/pipewire.py
@@ -13,7 +13,7 @@ class PipeWire(Bundle):
     The PipeWire class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["pipewire", "pipewire-alsa", "pipewire-audio", "pipewire-jack", "pipewire-media-session",
                 "pipewire-pulse", "pipewire-v4l2", "pipewire-x11-bell", "pipewire-zeroconf"]
 

--- a/src/bundles/plasma.py
+++ b/src/bundles/plasma.py
@@ -5,6 +5,7 @@ The plasma bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -45,7 +46,7 @@ class Plasma(Bundle):
         self.plasma_wayland = prompt_bool(_("Install Wayland support for the plasma session ? (y/N) : "),
                                           default=False)
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable sddm"')
         if "fr" in pre_launch_info["keymap"]:
             setup_chroot_keyboard("fr")

--- a/src/bundles/plasma.py
+++ b/src/bundles/plasma.py
@@ -18,7 +18,7 @@ class Plasma(Bundle):
     minimal = False
     plasma_wayland = False
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["plasma", "xorg-server", "alsa-utils", "pulseaudio", "pulseaudio-alsa",
                     "xdg-desktop-portal", "xdg-desktop-portal-kde"]
         if self.plasma_wayland:

--- a/src/bundles/sway.py
+++ b/src/bundles/sway.py
@@ -16,7 +16,7 @@ class Sway(Bundle):
     Bundle class.
     """
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["sway", "dmenu", "bemenu-wayland", "j4-dmenu-desktop", "foot", "grim", "mako", "slurp", "swayidle",
                     "swaylock", "swayimg", "waybar", "swaybg", "wf-recorder", "wl-clipboard", "xorg-xwayland",
                     "alsa-utils", "pulseaudio", "pulseaudio-alsa", "pavucontrol", "system-config-printer",

--- a/src/bundles/sway.py
+++ b/src/bundles/sway.py
@@ -5,6 +5,7 @@ The sway bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -28,7 +29,7 @@ class Sway(Bundle):
         print_sub_step(_("Desktop environment : %s") % self.name)
         print_sub_step(_("Display manager : %s") % _("none"))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute('arch-chroot /mnt bash -c "systemctl enable acpid"')
         if "fr" in pre_launch_info["keymap"]:
             execute("echo 'XKB_DEFAULT_LAYOUT=fr' >> /mnt/etc/environment")

--- a/src/bundles/terminus.py
+++ b/src/bundles/terminus.py
@@ -15,7 +15,7 @@ class TerminusFont(Bundle):
     The Terminus console font class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["terminus-font"]
 
     def print_resume(self):

--- a/src/bundles/terminus.py
+++ b/src/bundles/terminus.py
@@ -4,6 +4,7 @@ The terminus console font bundle module
 
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, execute
 
 _ = I18n().gettext
@@ -20,5 +21,5 @@ class TerminusFont(Bundle):
     def print_resume(self):
         print_sub_step(_("Install terminus console font."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         execute(f'echo "FONT={pre_launch_info["live_console_font"]}" >>/mnt/etc/vconsole.conf')

--- a/src/bundles/xfce.py
+++ b/src/bundles/xfce.py
@@ -5,6 +5,7 @@ The xfce bundle module
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
 from src.localesetup import setup_chroot_keyboard
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, prompt_bool, execute
 
 _ = I18n().gettext
@@ -41,7 +42,7 @@ class Xfce(Bundle):
             default=False,
             help_msg=_("If yes, the script will not install any extra packages, only base packages."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         if self.display_manager:
             execute('arch-chroot /mnt bash -c "systemctl enable lightdm"')
         execute(

--- a/src/bundles/xfce.py
+++ b/src/bundles/xfce.py
@@ -18,7 +18,7 @@ class Xfce(Bundle):
     display_manager = True
     minimal = False
 
-    def packages(self, system_info) -> [str]:
+    def packages(self, system_info) -> list[str]:
         packages = ["xfce4", "xorg-server", "alsa-utils", "pulseaudio", "pulseaudio-alsa", "pavucontrol",
                     "network-manager-applet"]
         if self.display_manager:

--- a/src/bundles/zram.py
+++ b/src/bundles/zram.py
@@ -14,7 +14,7 @@ class Zram(Bundle):
     The ZRAM class.
     """
 
-    def packages(self, system_info: {}) -> [str]:
+    def packages(self, system_info: dict[str, any]) -> list[str]:
         return ["zram-generator"]
 
     def print_resume(self):

--- a/src/bundles/zram.py
+++ b/src/bundles/zram.py
@@ -3,6 +3,7 @@ The zram bundle module
 """
 from src.bundles.bundle import Bundle
 from src.i18n import I18n
+from src.partitioninginfo import PartitioningInfo
 from src.utils import print_sub_step, log
 
 _ = I18n().gettext
@@ -19,7 +20,7 @@ class Zram(Bundle):
     def print_resume(self):
         print_sub_step(_("Install and enable ZRAM."))
 
-    def configure(self, system_info, pre_launch_info, partitioning_info):
+    def configure(self, system_info, pre_launch_info, partitioning_info: PartitioningInfo):
         content = [
             "[zram0]\n",
             "zram-size = ram / 2\n"

--- a/src/disk.py
+++ b/src/disk.py
@@ -25,7 +25,7 @@ class Disk:
         Disk initialisation.
         """
         self.path = path
-        detected_partitions = stdout(execute(f'lsblk -nl "{path}" -o PATH,TYPE | grep part', capture_output=True,
+        detected_partitions = stdout(execute(f'lsblk -nld "{path}" -o PATH,TYPE | grep part', capture_output=True,
                                              force=True, check=False))
         self.partitions = []
         index = 0

--- a/src/disk.py
+++ b/src/disk.py
@@ -25,8 +25,9 @@ class Disk:
         Disk initialisation.
         """
         self.path = path
-        detected_partitions = stdout(execute(f'lsblk -nld "{path}" -o PATH,TYPE | grep part', capture_output=True,
-                                             force=True, check=False))
+        detected_partitions = stdout(
+            execute(f'lsblk -nl "{path}" -o PATH,TYPE,PARTTYPENAME | grep part | grep -iE "linux|efi|swap"',
+                    capture_output=True, force=True, check=False))
         self.partitions = []
         index = 0
         for partition_info in detected_partitions.splitlines():

--- a/src/disk.py
+++ b/src/disk.py
@@ -52,7 +52,7 @@ class Disk:
         The Disk method to get the EFI partition if it exist. Else return an empty partition object.
         """
         try:
-            return [p for p in self.partitions if PartTypes.EFI in p.part_type].pop()
+            return [p for p in self.partitions if PartTypes.EFI in p.part_type_name].pop()
         except IndexError:
             return Partition(None)
 

--- a/src/disk.py
+++ b/src/disk.py
@@ -30,7 +30,7 @@ class Disk:
         self.partitions = []
         index = 0
         for partition_info in detected_partitions.splitlines():
-            self.partitions.append(Partition(index, partition_info))
+            self.partitions.append(Partition(index, partition_info.split(" ")[0]))
             index += 1
         self.total = int(
             stdout(execute(f'lsblk -b --output SIZE -n -d "{self.path}"', capture_output=True, force=True)))

--- a/src/envsetup.py
+++ b/src/envsetup.py
@@ -8,7 +8,7 @@ from src.utils import print_step, is_bios, print_error, print_sub_step, prompt_l
 _ = I18n().gettext
 
 
-def setup_environment(detected_language: str) -> {}:
+def setup_environment(detected_language: str) -> dict[str, any]:
     """
     The method to get environment configurations from the user.
     :param detected_language:

--- a/src/installer.py
+++ b/src/installer.py
@@ -53,7 +53,7 @@ def install(pre_launch_info):
 
         if pre_launch_info["global_language"].lower() != "en" and execute(
                 f"pacman -Si man-pages-{pre_launch_info['global_language'].lower()} &>/dev/null",
-            check=False).returncode == 0:
+                check=False).returncode == 0:
             pkgs.add(f"man-pages-{pre_launch_info['global_language'].lower()}")
 
         if partitioning_info.btrfs_in_use:

--- a/src/installer.py
+++ b/src/installer.py
@@ -184,7 +184,8 @@ def install(pre_launch_info):
                 f'--create-home {system_info["user_name"]}"')
             if system_info["user_full_name"] != "":
                 execute(
-                    f'arch-chroot /mnt bash -c "chfn -f \'{system_info["user_full_name"]}\' {system_info["user_name"]}"')
+                    f'arch-chroot /mnt bash -c '
+                    f'"chfn -f \'{system_info["user_full_name"]}\' {system_info["user_name"]}"')
             if system_info["user_password"] != "":
                 execute(
                     f'arch-chroot /mnt bash -c "echo \'{system_info["user_name"]}:'

--- a/src/installer.py
+++ b/src/installer.py
@@ -52,7 +52,8 @@ def install(pre_launch_info):
                      "pacman-contrib"])
 
         if pre_launch_info["global_language"].lower() != "en" and execute(
-                f"pacman -Si man-pages-{pre_launch_info['global_language'].lower()} &>/dev/null").returncode == 0:
+                f"pacman -Si man-pages-{pre_launch_info['global_language'].lower()} &>/dev/null",
+            check=False).returncode == 0:
             pkgs.add(f"man-pages-{pre_launch_info['global_language'].lower()}")
 
         if partitioning_info.btrfs_in_use:

--- a/src/installer.py
+++ b/src/installer.py
@@ -16,7 +16,7 @@ from src.utils import print_step, stdout, execute, prompt_bool, print_sub_step, 
 _ = I18n().gettext
 
 
-def umount_partitions():
+def umount_partitions(partitioning_info: PartitioningInfo):
     """
     A method to unmount all mounted partitions.
     """
@@ -26,159 +26,14 @@ def umount_partitions():
     if swap != "":
         execute(f'swapoff {swap} &>/dev/null', check=False)
 
-    execute('umount -R /mnt &>/dev/null', check=False)
+    mounted_partitions = [partition for partition in partitioning_info.partitions if
+                          partition.part_mounted and partition.part_type != PartTypes.ROOT]
+    mounted_partitions.sort(key=lambda partition: len(partition.part_mount_point), reverse=True)
 
-
-def installation_steps(pre_launch_info):
-    """
-    The archlinux installation method.
-    :param pre_launch_info:
-    :return:
-    """
-    system_info = setup_system(pre_launch_info["detected_timezone"])
-    btrfs_in_use = False
-
-    temp_partitioning_info = None
-    while temp_partitioning_info is None:
-        print_step(_("Partitioning :"))
-        want_auto_part = prompt_bool(_("Do you want an automatic partitioning ? (y/N) : "), default=False)
-        if want_auto_part:
-            temp_partitioning_info = auto_partitioning()
-        else:
-            temp_partitioning_info = manual_partitioning()
-    partitioning_info: PartitioningInfo = temp_partitioning_info
-
-    print_step(_("Formatting and mounting partitions..."), clear=False)
-
-    partitioning_info.root_partition.format_partition()
-    if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
-        btrfs_in_use = True
-
-    for partition in partitioning_info.partitions:
-        if partition.part_format_type == FSFormats.BTRFS:
-            btrfs_in_use = True
-        elif partition.part_type != PartTypes.ROOT:
-            partition.format_partition()
-
-    print_step(_("Updating mirrors..."), clear=False)
-    execute('reflector --verbose -phttps -f10 -l10 --sort rate -a2 --save /etc/pacman.d/mirrorlist')
-
-    base_pkgs = set()
-    base_pkgs.update(["base", "base-devel", "linux-firmware"])
-
-    if system_info["kernel"]:
-        base_pkgs.update(system_info["kernel"].packages(system_info))
-
-    pkgs = set()
-    pkgs.update(["man-db", "man-pages", "texinfo", "nano", "vim", "git", "curl", "os-prober", "efibootmgr",
-                 "networkmanager", "xdg-user-dirs", "reflector", "numlockx", "net-tools", "polkit", "pacman-contrib"])
-
-    if pre_launch_info["global_language"].lower() != "en" and execute(
-            f"pacman -Si man-pages-{pre_launch_info['global_language'].lower()} &>/dev/null").returncode == 0:
-        pkgs.add(f"man-pages-{pre_launch_info['global_language'].lower()}")
-
-    if btrfs_in_use:
-        pkgs.add("btrfs-progs")
-
-    pkgs.update(system_info["microcodes"].packages(system_info))
-
-    if system_info["bootloader"]:
-        pkgs.update(system_info["bootloader"].packages(system_info))
-
-    for bundle in system_info["bundles"]:
-        pkgs.update(bundle.packages(system_info))
-
-    if len(system_info["more_pkgs"]) > 0:
-        pkgs.update(system_info["more_pkgs"])
-
-    print_step(_("Installation of the base..."), clear=False)
-    execute(f'pacstrap -K /mnt {" ".join(base_pkgs)}')
-
-    print_step(_("System configuration..."), clear=False)
-    execute('sed -i "s|#en_US.UTF-8 UTF-8|en_US.UTF-8 UTF-8|g" /mnt/etc/locale.gen')
-    execute('sed -i "s|#en_US ISO-8859-1|en_US ISO-8859-1|g" /mnt/etc/locale.gen')
-    if pre_launch_info["global_language"] == "FR":
-        execute('sed -i "s|#fr_FR.UTF-8 UTF-8|fr_FR.UTF-8 UTF-8|g" /mnt/etc/locale.gen')
-        execute('sed -i "s|#fr_FR ISO-8859-1|fr_FR ISO-8859-1|g" /mnt/etc/locale.gen')
-        execute('echo "LANG=fr_FR.UTF-8" >/mnt/etc/locale.conf')
-    else:
-        execute('echo "LANG=en_US.UTF-8" >/mnt/etc/locale.conf')
-    execute(f'echo "KEYMAP={pre_launch_info["keymap"]}" >/mnt/etc/vconsole.conf')
-    execute(f'echo "{system_info["hostname"]}" >/mnt/etc/hostname')
-    execute(f'''
-        {{
-            echo "127.0.0.1 localhost"
-            echo "::1 localhost"
-            echo "127.0.1.1 {system_info["hostname"]}.localdomain {system_info["hostname"]}"
-        }} >>/mnt/etc/hosts
-    ''')
-    execute('cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist')
-
-    print_step(_("Locales configuration..."), clear=False)
-    execute(f'arch-chroot /mnt bash -c "ln -sf {system_info["timezone"]} /etc/localtime"')
-    execute('arch-chroot /mnt bash -c "locale-gen"')
-
-    print_step(_("Installation of the remaining packages..."), clear=False)
-    execute('sed -i "s|#Color|Color|g" /mnt/etc/pacman.conf')
-    execute('sed -i "s|#ParallelDownloads = 5|ParallelDownloads = 5\\nDisableDownloadTimeout|g" /mnt/etc/pacman.conf')
-    execute('arch-chroot /mnt bash -c "pacman --noconfirm -Sy archlinux-keyring"')
-    execute('arch-chroot /mnt bash -c "pacman --noconfirm -Su"')
-    execute(f'arch-chroot /mnt bash -c "pacman --noconfirm -S {" ".join(pkgs)}"')
-
-    if PartTypes.SWAP not in [part.part_type for part in
-                              partitioning_info.partitions] and partitioning_info.swapfile_size:
-        print_step(_("Creation and activation of the swapfile..."), clear=False)
-        if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
-            execute(
-                "btrfs subvolume create /mnt/swap && "
-                "cd /mnt/swap && "
-                "truncate -s 0 ./swapfile && "
-                "chattr +C ./swapfile && "
-                "btrfs property set ./swapfile compression none && "
-                "cd -")
-        else:
-            execute("mkdir -p /mnt/swap")
-        execute(f'fallocate -l "{partitioning_info.swapfile_size}" /mnt/swap/swapfile')
-        execute('chmod 600 /mnt/swap/swapfile')
-        execute('mkswap /mnt/swap/swapfile')
-        execute('swapon /mnt/swap/swapfile')
-
-    print_step(_("Generating fstab..."), clear=False)
-    execute('genfstab -U /mnt >>/mnt/etc/fstab')
-
-    print_step(_("Network configuration..."), clear=False)
-    execute('arch-chroot /mnt bash -c "systemctl enable NetworkManager"')
-    execute('arch-chroot /mnt bash -c "systemctl enable systemd-timesyncd"')
-
-    if system_info["bootloader"]:
-        print_step(_("Installation and configuration of the grub..."), clear=False)
-        system_info["bootloader"].configure(system_info, pre_launch_info, partitioning_info)
-
-    print_step(_("Users configuration..."), clear=False)
-    print_sub_step(_("Root account configuration..."))
-    if system_info["root_password"] != "":
-        execute(f'arch-chroot /mnt bash -c "echo \'root:{system_info["root_password"]}\' | chpasswd"')
-    if system_info["user_name"] != "":
-        print_sub_step(_("%s account configuration...") % system_info["user_name"])
-        execute('sed -i "s|# %wheel ALL=(ALL:ALL) ALL|%wheel ALL=(ALL:ALL) ALL|g" /mnt/etc/sudoers')
-        execute(
-            f'arch-chroot /mnt bash -c "useradd --shell=/bin/bash --groups=wheel '
-            f'--create-home {system_info["user_name"]}"')
-        if system_info["user_full_name"] != "":
-            execute(
-                f'arch-chroot /mnt bash -c "chfn -f \'{system_info["user_full_name"]}\' {system_info["user_name"]}"')
-        if system_info["user_password"] != "":
-            execute(
-                f'arch-chroot /mnt bash -c "echo \'{system_info["user_name"]}:'
-                f'{system_info["user_password"]}\' | chpasswd"')
-
-    print_step(_("Extra packages configuration if needed..."), clear=False)
-    for bundle in system_info["bundles"]:
-        bundle.configure(system_info, pre_launch_info, partitioning_info)
-
-    umount_partitions()
-
-    print_step(_("Installation complete ! You can reboot your system."), clear=False)
+    while True in [partition.part_mounted for partition in mounted_partitions]:
+        for partition in [partition for partition in mounted_partitions if partition.part_mounted]:
+            partition.umount()
+    partitioning_info.root_partition.umount()
 
 
 def install(pre_launch_info):
@@ -187,15 +42,169 @@ def install(pre_launch_info):
     :param pre_launch_info:
     :return:
     """
+    partitioning_info: PartitioningInfo = PartitioningInfo()
     try:
-        installation_steps(pre_launch_info)
+        system_info = setup_system(pre_launch_info["detected_timezone"])
+        btrfs_in_use = False
+
+        temp_partitioning_info = None
+        while temp_partitioning_info is None:
+            print_step(_("Partitioning :"))
+            want_auto_part = prompt_bool(_("Do you want an automatic partitioning ? (y/N) : "), default=False)
+            if want_auto_part:
+                temp_partitioning_info = auto_partitioning()
+            else:
+                temp_partitioning_info = manual_partitioning()
+        partitioning_info: PartitioningInfo = temp_partitioning_info
+
+        print_step(_("Formatting and mounting partitions..."), clear=False)
+
+        print_sub_step(_("Formatting %s...") % (partitioning_info.root_partition.real_path()))
+        partitioning_info.root_partition.format_partition()
+        print_sub_step(_("Mounting %s...") % (partitioning_info.root_partition.real_path()))
+        partitioning_info.root_partition.mount()
+
+        if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
+            btrfs_in_use = True
+
+        for partition in partitioning_info.partitions:
+            if partition.part_format_type == FSFormats.BTRFS:
+                btrfs_in_use = True
+            elif partition.part_type != PartTypes.ROOT:
+                print_sub_step(_("Formatting %s...") % (partition.real_path()))
+                partition.format_partition()
+                print_sub_step(_("Mounting %s...") % (partition.real_path()))
+                partition.mount()
+
+        print_step(_("Updating mirrors..."), clear=False)
+        execute('reflector --verbose -phttps -f10 -l10 --sort rate -a2 --save /etc/pacman.d/mirrorlist')
+
+        base_pkgs = set()
+        base_pkgs.update(["base", "base-devel", "linux-firmware"])
+
+        if system_info["kernel"]:
+            base_pkgs.update(system_info["kernel"].packages(system_info))
+
+        pkgs = set()
+        pkgs.update(["man-db", "man-pages", "texinfo", "nano", "vim", "git", "curl", "os-prober", "efibootmgr",
+                     "networkmanager", "xdg-user-dirs", "reflector", "numlockx", "net-tools", "polkit",
+                     "pacman-contrib"])
+
+        if pre_launch_info["global_language"].lower() != "en" and execute(
+                f"pacman -Si man-pages-{pre_launch_info['global_language'].lower()} &>/dev/null").returncode == 0:
+            pkgs.add(f"man-pages-{pre_launch_info['global_language'].lower()}")
+
+        if btrfs_in_use:
+            pkgs.add("btrfs-progs")
+
+        pkgs.update(system_info["microcodes"].packages(system_info))
+
+        if system_info["bootloader"]:
+            pkgs.update(system_info["bootloader"].packages(system_info))
+
+        for bundle in system_info["bundles"]:
+            pkgs.update(bundle.packages(system_info))
+
+        if len(system_info["more_pkgs"]) > 0:
+            pkgs.update(system_info["more_pkgs"])
+
+        print_step(_("Installation of the base..."), clear=False)
+        execute(f'pacstrap -K /mnt {" ".join(base_pkgs)}')
+
+        print_step(_("System configuration..."), clear=False)
+        execute('sed -i "s|#en_US.UTF-8 UTF-8|en_US.UTF-8 UTF-8|g" /mnt/etc/locale.gen')
+        execute('sed -i "s|#en_US ISO-8859-1|en_US ISO-8859-1|g" /mnt/etc/locale.gen')
+        if pre_launch_info["global_language"] == "FR":
+            execute('sed -i "s|#fr_FR.UTF-8 UTF-8|fr_FR.UTF-8 UTF-8|g" /mnt/etc/locale.gen')
+            execute('sed -i "s|#fr_FR ISO-8859-1|fr_FR ISO-8859-1|g" /mnt/etc/locale.gen')
+            execute('echo "LANG=fr_FR.UTF-8" >/mnt/etc/locale.conf')
+        else:
+            execute('echo "LANG=en_US.UTF-8" >/mnt/etc/locale.conf')
+        execute(f'echo "KEYMAP={pre_launch_info["keymap"]}" >/mnt/etc/vconsole.conf')
+        execute(f'echo "{system_info["hostname"]}" >/mnt/etc/hostname')
+        execute(f'''
+            {{
+                echo "127.0.0.1 localhost"
+                echo "::1 localhost"
+                echo "127.0.1.1 {system_info["hostname"]}.localdomain {system_info["hostname"]}"
+            }} >>/mnt/etc/hosts
+        ''')
+        execute('cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist')
+
+        print_step(_("Locales configuration..."), clear=False)
+        execute(f'arch-chroot /mnt bash -c "ln -sf {system_info["timezone"]} /etc/localtime"')
+        execute('arch-chroot /mnt bash -c "locale-gen"')
+
+        print_step(_("Installation of the remaining packages..."), clear=False)
+        execute('sed -i "s|#Color|Color|g" /mnt/etc/pacman.conf')
+        execute(
+            'sed -i "s|#ParallelDownloads = 5|ParallelDownloads = 5\\nDisableDownloadTimeout|g" /mnt/etc/pacman.conf')
+        execute('arch-chroot /mnt bash -c "pacman --noconfirm -Sy archlinux-keyring"')
+        execute('arch-chroot /mnt bash -c "pacman --noconfirm -Su"')
+        execute(f'arch-chroot /mnt bash -c "pacman --noconfirm -S {" ".join(pkgs)}"')
+
+        if PartTypes.SWAP not in [part.part_type for part in
+                                  partitioning_info.partitions] and partitioning_info.swapfile_size:
+            print_step(_("Creation and activation of the swapfile..."), clear=False)
+            if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
+                execute(
+                    "btrfs subvolume create /mnt/swap && "
+                    "cd /mnt/swap && "
+                    "truncate -s 0 ./swapfile && "
+                    "chattr +C ./swapfile && "
+                    "btrfs property set ./swapfile compression none && "
+                    "cd -")
+            else:
+                execute("mkdir -p /mnt/swap")
+            execute(f'fallocate -l "{partitioning_info.swapfile_size}" /mnt/swap/swapfile')
+            execute('chmod 600 /mnt/swap/swapfile')
+            execute('mkswap /mnt/swap/swapfile')
+            execute('swapon /mnt/swap/swapfile')
+
+        print_step(_("Generating fstab..."), clear=False)
+        execute('genfstab -U /mnt >>/mnt/etc/fstab')
+
+        print_step(_("Network configuration..."), clear=False)
+        execute('arch-chroot /mnt bash -c "systemctl enable NetworkManager"')
+        execute('arch-chroot /mnt bash -c "systemctl enable systemd-timesyncd"')
+
+        if system_info["bootloader"]:
+            print_step(_("Installation and configuration of the grub..."), clear=False)
+            system_info["bootloader"].configure(system_info, pre_launch_info, partitioning_info)
+
+        print_step(_("Users configuration..."), clear=False)
+        print_sub_step(_("Root account configuration..."))
+        if system_info["root_password"] != "":
+            execute(f'arch-chroot /mnt bash -c "echo \'root:{system_info["root_password"]}\' | chpasswd"')
+        if system_info["user_name"] != "":
+            print_sub_step(_("%s account configuration...") % system_info["user_name"])
+            execute('sed -i "s|# %wheel ALL=(ALL:ALL) ALL|%wheel ALL=(ALL:ALL) ALL|g" /mnt/etc/sudoers')
+            execute(
+                f'arch-chroot /mnt bash -c "useradd --shell=/bin/bash --groups=wheel '
+                f'--create-home {system_info["user_name"]}"')
+            if system_info["user_full_name"] != "":
+                execute(
+                    f'arch-chroot /mnt bash -c "chfn -f \'{system_info["user_full_name"]}\' {system_info["user_name"]}"')
+            if system_info["user_password"] != "":
+                execute(
+                    f'arch-chroot /mnt bash -c "echo \'{system_info["user_name"]}:'
+                    f'{system_info["user_password"]}\' | chpasswd"')
+
+        print_step(_("Extra packages configuration if needed..."), clear=False)
+        for bundle in system_info["bundles"]:
+            bundle.configure(system_info, pre_launch_info, partitioning_info)
+
+        umount_partitions(partitioning_info)
+
+        print_step(_("Installation complete ! You can reboot your system."), clear=False)
+
     except KeyboardInterrupt:
         print_error(_("Script execution interrupted by the user !"), do_pause=False)
-        umount_partitions()
+        umount_partitions(partitioning_info)
         sys.exit(1)
     except CalledProcessError as exception:
         print_error(_("A subprocess execution failed ! See the following error: %s") % exception, do_pause=False)
-        umount_partitions()
+        umount_partitions(partitioning_info)
         sys.exit(1)
     except EOFError:
         sys.exit(1)

--- a/src/installer.py
+++ b/src/installer.py
@@ -59,22 +59,22 @@ def install(pre_launch_info):
 
         print_step(_("Formatting and mounting partitions..."), clear=False)
 
-        print_sub_step(_("Formatting %s...") % (partitioning_info.root_partition.real_path()))
-        partitioning_info.root_partition.format_partition()
-        print_sub_step(_("Mounting %s...") % (partitioning_info.root_partition.real_path()))
-        partitioning_info.root_partition.mount()
-
-        if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
-            btrfs_in_use = True
-
         for partition in partitioning_info.partitions:
             if partition.part_format_type == FSFormats.BTRFS:
                 btrfs_in_use = True
-            elif partition.part_type != PartTypes.ROOT:
-                print_sub_step(_("Formatting %s...") % (partition.real_path()))
-                partition.format_partition()
-                print_sub_step(_("Mounting %s...") % (partition.real_path()))
-                partition.mount()
+            print_sub_step(_("Formatting %s...") % (partition.real_path()))
+            partition.format_partition()
+
+        if partitioning_info.root_partition.part_format_type == FSFormats.BTRFS:
+            btrfs_in_use = True
+        print_sub_step(_("Mounting %s...") % (partitioning_info.root_partition.real_path()))
+        partitioning_info.root_partition.mount()
+
+        for partition in [partition for partition in partitioning_info.partitions if not partition.part_mounted]:
+            if partition.part_format_type == FSFormats.BTRFS:
+                btrfs_in_use = True
+            print_sub_step(_("Mounting %s...") % (partition.real_path()))
+            partition.mount()
 
         print_step(_("Updating mirrors..."), clear=False)
         execute('reflector --verbose -phttps -f10 -l10 --sort rate -a2 --save /etc/pacman.d/mirrorlist')

--- a/src/manualpart.py
+++ b/src/manualpart.py
@@ -43,7 +43,7 @@ def manual_partitioning() -> PartitioningInfo or None:
         for disk in partitioned_disks:
             log(f"Detected disk: {disk}")
             detected_partitions = stdout(execute(
-                f'lsblk -nl "{disk}" -o PATH,PARTTYPENAME | grep -iE "linux|efi|swap" | awk \'{{print $1}}\'',
+                f'lsblk -nld "{disk}" -o PATH,PARTTYPENAME | grep -iE "linux|efi|swap" | awk \'{{print $1}}\'',
                 capture_output=True, force=True))
             log(f"Partitions: {detected_partitions.splitlines()}")
             for partition in detected_partitions.splitlines():

--- a/src/manualpart.py
+++ b/src/manualpart.py
@@ -97,8 +97,9 @@ def manual_partitioning() -> PartitioningInfo or None:
             partitioning_info.partitions.clear()
             partitioned_disks.clear()
             continue
-        if True in [part.encrypted for part in partitioning_info.partitions] and PartTypes.BOOT not in \
-                [part.part_type for part in partitioning_info.partitions]:
+        if True in [part.encrypted and part.part_type == PartTypes.ROOT for part in
+                    partitioning_info.partitions] and PartTypes.BOOT not in [part.part_type for part in
+                                                                             partitioning_info.partitions]:
             print_error(_("The Boot partition is required for system installation."))
             partitioning_info.partitions.clear()
             partitioned_disks.clear()

--- a/src/manualpart.py
+++ b/src/manualpart.py
@@ -9,7 +9,7 @@ from src.options import PartTypes
 from src.partition import Partition
 from src.partitioninginfo import PartitioningInfo
 from src.utils import is_bios, print_error, print_step, print_sub_step, prompt, prompt_bool, prompt_option, execute, \
-    stdout, log
+    log
 
 _ = I18n().gettext
 
@@ -40,13 +40,12 @@ def manual_partitioning() -> PartitioningInfo or None:
         other_drive = prompt_bool(_("Do you want to partition an other drive ? (y/N) : "), default=False)
         if other_drive:
             continue
-        for disk in partitioned_disks:
-            log(f"Detected disk: {disk}")
-            detected_partitions = stdout(execute(
-                f'lsblk -nld "{disk}" -o PATH,PARTTYPENAME | grep -iE "linux|efi|swap" | awk \'{{print $1}}\'',
-                capture_output=True, force=True))
-            log(f"Partitions: {detected_partitions.splitlines()}")
-            for partition in detected_partitions.splitlines():
+        for disk_path in partitioned_disks:
+            log(f"Detected disk: {disk_path}")
+            disk = Disk(disk_path)
+            partitions = [partition.path for partition in disk.partitions]
+            log(f"Partitions: {partitions}")
+            for partition in partitions:
                 log(f"Partition : {partition}")
                 partitioning_info.partitions.append(Partition(path=partition))
         print_step(

--- a/src/manualpart.py
+++ b/src/manualpart.py
@@ -7,21 +7,22 @@ import re
 from src.disk import Disk
 from src.i18n import I18n
 from src.options import PartTypes, FSFormats
+from src.partition import Partition
+from src.partitioninginfo import PartitioningInfo
 from src.utils import is_bios, ask_format_type, \
     print_error, print_step, print_sub_step, prompt, prompt_bool, prompt_option, execute, stdout, log
 
 _ = I18n().gettext
 
 
-def manual_partitioning() -> {}:
+def manual_partitioning() -> PartitioningInfo or None:
     """
-    The method to proceed to the manual partitioning.=
+    The method to proceed to the manual partitioning.
     :return:
     """
-    partitioning_info = {"partitions": [], "part_type": {}, "part_mount_point": {}, "part_format": {},
-                         "part_format_type": {}, "root_partition": None, "swapfile_size": None, "main_disk": None}
+    partitioning_info = PartitioningInfo()
     user_answer = False
-    partitioned_disks = set()
+    partitioned_disks = []
     while not user_answer:
         print_step(_("Manual partitioning :"))
         print_sub_step(_("Partitioned drives so far : %s") % " ".join(partitioned_disks))
@@ -31,7 +32,8 @@ def manual_partitioning() -> {}:
         if not os.path.exists(target_disk):
             print_error(_("The chosen target drive doesn't exist."))
             continue
-        partitioned_disks.add(target_disk)
+        if target_disk not in partitioned_disks:
+            partitioned_disks.append(target_disk)
         execute(f'cfdisk "{target_disk}"')
         print_step(_("Manual partitioning :"))
         print_sub_step(_("Partitioned drives so far : %s") % " ".join(partitioned_disks))
@@ -47,12 +49,12 @@ def manual_partitioning() -> {}:
             log(f"Partitions: {detected_partitions.splitlines()}")
             for partition in detected_partitions.splitlines():
                 log(f"Partition : {partition}")
-                partitioning_info["partitions"].append(partition)
-        print_step(_("Detected target drive partitions : %s") % " ".join(partitioning_info["partitions"]))
-        for partition in partitioning_info["partitions"]:
+                partitioning_info.partitions.append(Partition(path=partition))
+        print_step(
+            _("Detected target drive partitions : %s") % " ".join([part.path for part in partitioning_info.partitions]))
+        for partition in partitioning_info.partitions:
             print_step(_("Partition :"), clear=False)
-            print_sub_step(re.sub('\n', '', stdout(
-                execute(f'lsblk -nl "{partition}" -o PATH,SIZE,PARTTYPENAME', capture_output=True, force=True))))
+            print_sub_step(partition)
             if is_bios():
                 partition_type = prompt_option(_("What is the role of this partition ? (%s) : "),
                                                _("Partition type '%s' is not supported."), PartTypes,
@@ -63,81 +65,61 @@ def manual_partitioning() -> {}:
                                                _("Partition type '%s' is not supported."), PartTypes,
                                                _("Supported partition types : "), PartTypes.OTHER)
             if not is_bios() and partition_type == PartTypes.EFI:
-                partitioning_info["part_type"][partition] = PartTypes.EFI
-                partitioning_info["part_mount_point"][partition] = "/boot/efi"
-                partitioning_info["part_format"][partition] = prompt_bool(_("Format the EFI partition ? (Y/n) : "))
-                if partitioning_info["part_format"].get(partition):
-                    partitioning_info["part_format_type"][partition] = FSFormats.VFAT
+                partition.part_type = PartTypes.EFI
+                partition.part_mount_point = "/boot/efi"
+                partition.part_format = prompt_bool(_("Format the EFI partition ? (Y/n) : "))
+                if partition.part_format:
+                    partition.part_format_type = FSFormats.VFAT
             elif partition_type == PartTypes.ROOT:
-                partitioning_info["part_type"][partition] = PartTypes.ROOT
-                partitioning_info["part_mount_point"][partition] = "/"
-                partitioning_info["part_format_type"][partition] = ask_format_type()
-                partitioning_info["root_partition"] = partition
+                partition.part_type = PartTypes.ROOT
+                partition.part_mount_point = "/"
+                partition.part_format_type = ask_format_type()
+                partitioning_info.root_partition = partition
                 main_disk_label = re.sub('\\s+', '',
-                                         stdout(execute(f'lsblk -ndo PKNAME {partition}', capture_output=True,
+                                         stdout(execute(f'lsblk -ndo PKNAME {partition.path}', capture_output=True,
                                                         force=True)))
-                partitioning_info["main_disk"] = f'/dev/{main_disk_label}'
+                partitioning_info.main_disk = f'/dev/{main_disk_label}'
             elif partition_type == PartTypes.HOME:
-                partitioning_info["part_type"][partition] = PartTypes.HOME
-                partitioning_info["part_mount_point"][partition] = "/home"
-                partitioning_info["part_format"][partition] = prompt_bool(_("Format the Home partition ? (Y/n) : "))
-                if partitioning_info["part_format"].get(partition):
-                    partitioning_info["part_format_type"][partition] = ask_format_type()
+                partition.part_type = PartTypes.HOME
+                partition.part_mount_point = "/home"
+                partition.part_format = prompt_bool(_("Format the Home partition ? (Y/n) : "))
+                if partition.part_format:
+                    partition.part_format_type = ask_format_type()
             elif partition_type == PartTypes.SWAP:
-                partitioning_info["part_type"][partition] = PartTypes.SWAP
+                partition.part_type = PartTypes.SWAP
             elif partition_type == PartTypes.NOT_USED:
                 continue
             elif partition_type == PartTypes.OTHER:
-                partitioning_info["part_type"][partition] = PartTypes.OTHER
-                partitioning_info["part_mount_point"][partition] = prompt(
+                partition.part_type = PartTypes.OTHER
+                partition.part_mount_point = prompt(
                     _("What is the mounting point of this partition ? : "))
-                partitioning_info["part_format"][partition] = prompt_bool(
+                partition.part_format = prompt_bool(
                     _("Format the %s partition ? (Y/n) : ") % partition)
-                if partitioning_info["part_format"].get(partition):
-                    partitioning_info["part_format_type"][partition] = ask_format_type()
-        if not is_bios() and PartTypes.EFI not in partitioning_info["part_type"].values():
+                if partition.part_format:
+                    partition.part_format_type = ask_format_type()
+        if not is_bios() and PartTypes.EFI not in [part.part_type for part in partitioning_info.partitions]:
             print_error(_("The EFI partition is required for system installation."))
-            partitioning_info["partitions"].clear()
+            partitioning_info.partitions.clear()
             partitioned_disks.clear()
             continue
-        if PartTypes.ROOT not in partitioning_info["part_type"].values():
+        if PartTypes.ROOT not in [part.part_type for part in partitioning_info.partitions]:
             print_error(_("The Root partition is required for system installation."))
-            partitioning_info["partitions"].clear()
+            partitioning_info.partitions.clear()
             partitioned_disks.clear()
             continue
-        if PartTypes.SWAP not in partitioning_info["part_type"].values():
-            partitioning_info["swapfile_size"] = Disk(partitioning_info["main_disk"]).ask_swapfile_size()
+        if PartTypes.SWAP not in [part.part_type for part in partitioning_info.partitions]:
+            partitioning_info.swapfile_size = Disk(partitioning_info.main_disk).ask_swapfile_size()
         print_step(_("Summary of choices :"))
-        for partition in partitioning_info["partitions"]:
-            if partitioning_info["part_format"].get(partition):
-                formatting = _("yes")
-            else:
-                formatting = _("no")
-            if partitioning_info["part_type"].get(partition) == PartTypes.EFI:
-                print_sub_step(_("EFI partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (partition, partitioning_info["part_mount_point"].get(partition), formatting,
-                                  partitioning_info["part_format_type"].get(partition)))
-            if partitioning_info["part_type"].get(partition) == PartTypes.ROOT:
-                print_sub_step(_("ROOT partition : %s (mounting point : %s, format type %s)")
-                               % (partition, partitioning_info["part_mount_point"].get(partition),
-                                  partitioning_info["part_format_type"].get(partition)))
-            if partitioning_info["part_type"].get(partition) == PartTypes.HOME:
-                print_sub_step(_("Home partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (partition, partitioning_info["part_mount_point"].get(partition), formatting,
-                                  partitioning_info["part_format_type"].get(partition)))
-            if partitioning_info["part_type"].get(partition) == PartTypes.SWAP:
-                print_sub_step(_("Swap partition : %s") % partition)
-            if partitioning_info["part_type"].get(partition) == PartTypes.OTHER:
-                print_sub_step(_("Other partition : %s (mounting point : %s, format %s, format type %s)")
-                               % (partition, partitioning_info["part_mount_point"].get(partition), formatting,
-                                  partitioning_info["part_format_type"].get(partition)))
-        if PartTypes.SWAP not in partitioning_info["part_type"].values() and partitioning_info["swapfile_size"]:
-            print_sub_step(_("Swapfile size : %s") % partitioning_info["swapfile_size"])
+        for partition in partitioning_info.partitions:
+            print_sub_step(partition.summary())
+        if PartTypes.SWAP not in [part.part_type for part in
+                                  partitioning_info.partitions] and partitioning_info.swapfile_size:
+            print_sub_step(_("Swapfile size : %s") % partitioning_info.swapfile_size)
         user_answer = prompt_bool(_("Is the informations correct ? (y/N) : "), default=False)
         if not user_answer:
             want_to_change = prompt_bool(_("Do you want to change the partitioning mode ? (y/N) : "), default=False)
             if want_to_change:
                 return None
-            partitioning_info["partitions"].clear()
+            partitioning_info.partitions.clear()
             partitioned_disks.clear()
     return partitioning_info

--- a/src/options.py
+++ b/src/options.py
@@ -117,6 +117,7 @@ class PartTypes(OptionEnum):
     """
     EFI = auto()
     ROOT = auto()
+    BOOT = auto()
     HOME = auto()
     SWAP = auto()
     NOT_USED = auto()

--- a/src/partition.py
+++ b/src/partition.py
@@ -1,10 +1,13 @@
 """
 The partition class module
 """
+import json
+import os
 import re
 
 from src.i18n import I18n
-from src.utils import from_iec, execute, stdout, prompt_bool, prompt_ln, ask_password, print_error
+from src.options import PartTypes, FSFormats
+from src.utils import from_iec, execute, stdout, prompt_bool, prompt_ln, ask_password, print_error, to_iec
 
 _ = I18n().gettext
 
@@ -16,36 +19,64 @@ class Partition:
     index: int
     path: str
     size: int
-    part_type: str
+    part_type_name: str
     fs_type: str
+    part_type: PartTypes
+    part_mount_point: str
+    part_format_type: FSFormats
+    part_format: bool
+
     encrypted: bool = False
     block_name: str = None
     block_password: str = None
 
-    def __init__(self, index: int or None, path: str = None, compute: bool = True):
+    def __init__(self, index: int or None = None, path: str = None, part_type: PartTypes = None,
+                 part_mount_point: str = None,
+                 part_format_type: FSFormats = None, part_format: bool = True, compute: bool = True):
         """
         Partition initialisation.
         """
         self.index = index
+        self.part_type = part_type
+        self.part_mount_point = part_mount_point
+        self.part_format_type = part_format_type
+        self.part_format = part_format
         if path is None:
             self.path = ""
             self.size = 0
-            self.part_type = ""
+            self.part_type_name = ""
             self.fs_type = ""
         else:
             self.path = path
             if compute:
                 self.compute()
 
+    def __str__(self) -> str:
+        """
+        Partition str formatting.
+        """
+        formatted_str = f"'{self.path}' - '{self.part_type_name}' - '{to_iec(int(self.size))}'"
+        if self.encrypted:
+            formatted_str += f" - encrypted ('/dev/mapper/{self.block_name}')"
+        return formatted_str
+
     def compute(self):
+        """
+        A method to compute partition information.
+        :return:
+        """
         self.size = from_iec(re.sub('\\s', '', stdout(
             execute(f'lsblk -nl "{self.path}" -o SIZE', capture_output=True, force=True))))
-        self.part_type = str(re.sub('[^a-zA-Z\\d ]', '', stdout(
+        self.part_type_name = str(re.sub('[^a-zA-Z\\d ]', '', stdout(
             execute(f'lsblk -nl "{self.path}" -o PARTTYPENAME', capture_output=True, force=True))))
         self.fs_type = str(re.sub('[^a-zA-Z\\d ]', '', stdout(
             execute(f'lsblk -nl "{self.path}" -o FSTYPE', capture_output=True, force=True))))
 
     def ask_for_encryption(self):
+        """
+        A method to ask if the partition will be encrypted.
+        :return:
+        """
         self.encrypted = prompt_bool(_("Do you want to encrypt this partition ? (y/N) : "), default=False)
         if self.encrypted:
 
@@ -63,11 +94,75 @@ class Partition:
                 _("Enter the encrypted block password (it will be asked at boot to decrypt the partition) : "),
                 required=True)
 
-    def __str__(self) -> str:
+    def summary(self):
         """
-        Partition str formatting.
+        A method to get the partition summary.
+        :return:
         """
-        formatted_str = f"'{self.path}' - '{self.size}' - '{self.part_type}' - '{self.fs_type}'"
-        if self.encrypted:
-            formatted_str += f" - encrypted ('/dev/mapper/{self.block_name}')"
-        return formatted_str
+        if self.part_format:
+            formatting = _("yes")
+        else:
+            formatting = _("no")
+        name = "NO_NAME"
+        if self.index:
+            name = str(self.index + 1)
+        if self.path:
+            name = self.path
+        if self.part_type == PartTypes.SWAP:
+            return _("%s : %s") % (self.part_type, name)
+        return _("%s : %s (mounting point : %s, format %s, format type %s)") % (
+            self.part_type, name, self.part_mount_point, formatting, self.part_format_type)
+
+    def format_partition(self):
+        """
+        A method to execute formatting commands for the partition.
+        """
+        if self.part_type == PartTypes.SWAP:
+            execute(f'mkswap "{self.path}"')
+            execute(f'swapon "{self.path}"')
+            return
+        match self.part_format_type:
+            case FSFormats.VFAT:
+                if self.part_format:
+                    execute(f'mkfs.vfat "{self.path}"')
+                execute(f'mkdir -p "/mnt{self.part_mount_point}"')
+                execute(f'mount "{self.path}" "/mnt{self.part_mount_point}"')
+            case FSFormats.BTRFS:
+                if self.part_format:
+                    execute(f'mkfs.btrfs -f "{self.path}"')
+                execute(f'mkdir -p "/mnt{self.part_mount_point}"')
+                execute(f'mount -o compress=zstd "{self.path}" "/mnt{self.part_mount_point}"')
+            case _:
+                if self.part_format:
+                    execute(f'mkfs.ext4 "{self.path}"')
+                execute(f'mkdir -p "/mnt{self.part_mount_point}"')
+                execute(f'mount "{self.path}" "/mnt{self.part_mount_point}"')
+
+    def build_partition_name(self, disk_name: str):
+        """
+        A method to build a partition name with a disk and an index.
+        :param disk_name:
+        :return:
+        """
+        block_devices_str = stdout(execute('lsblk -J', capture_output=True, force=True))
+        if not block_devices_str:
+            return
+        block_devices_json = json.loads(block_devices_str)
+        if block_devices_json is None or not isinstance(block_devices_json, dict) or "blockdevices" not in dict(
+                block_devices_json):
+            return
+        block_devices = dict(block_devices_json).get("blockdevices")
+        if block_devices is None or not isinstance(block_devices, list):
+            return
+        disk = next((d for d in block_devices if
+                     d is not None and isinstance(d, dict) and "name" in d and dict(d).get("name") == os.path.basename(
+                         disk_name)), None)
+        if disk is None or not isinstance(disk, dict) or "children" not in dict(disk):
+            return
+        partitions = dict(disk).get("children")
+        if partitions is None or not isinstance(partitions, list) or len(list(partitions)) <= self.index:
+            return
+        partition = list(partitions)[self.index]
+        if partition is None or not isinstance(partition, dict) or "name" not in dict(partition):
+            return
+        self.path = f'/dev/{dict(partition).get("name")}'

--- a/src/partition.py
+++ b/src/partition.py
@@ -68,12 +68,12 @@ class Partition:
         :return:
         """
         self.size = from_iec(
-            stdout(execute(f'lsblk -nl "{self.path}" -o SIZE', capture_output=True, force=True)).strip())
+            stdout(execute(f'lsblk -nld "{self.path}" -o SIZE', capture_output=True, force=True)).strip())
         self.part_type_name = stdout(
-            execute(f'lsblk -nl "{self.path}" -o PARTTYPENAME', capture_output=True, force=True)).strip()
-        self.disk_name = stdout(execute(f'lsblk -nl "{self.path}" -o PKNAME', capture_output=True, force=True)).strip()
-        self.fs_type = stdout(execute(f'lsblk -nl "{self.path}" -o FSTYPE', capture_output=True, force=True)).strip()
-        self.uuid = stdout(execute(f'lsblk -nl "{self.path}" -o UUID', capture_output=True, force=True)).strip()
+            execute(f'lsblk -nld "{self.path}" -o PARTTYPENAME', capture_output=True, force=True)).strip()
+        self.disk_name = stdout(execute(f'lsblk -nld "{self.path}" -o PKNAME', capture_output=True, force=True)).strip()
+        self.fs_type = stdout(execute(f'lsblk -nld "{self.path}" -o FSTYPE', capture_output=True, force=True)).strip()
+        self.uuid = stdout(execute(f'lsblk -nld "{self.path}" -o UUID', capture_output=True, force=True)).strip()
 
     def need_format(self):
         """

--- a/src/partition.py
+++ b/src/partition.py
@@ -3,7 +3,10 @@ The partition class module
 """
 import re
 
-from src.utils import from_iec, execute, stdout
+from src.i18n import I18n
+from src.utils import from_iec, execute, stdout, prompt_bool, prompt_ln, ask_password, print_error
+
+_ = I18n().gettext
 
 
 class Partition:
@@ -15,30 +18,56 @@ class Partition:
     size: int
     part_type: str
     fs_type: str
+    encrypted: bool = False
+    block_name: str = None
+    block_password: str = None
 
-    def __init__(self, index: int or None, part_str: str = None):
+    def __init__(self, index: int or None, path: str = None, compute: bool = True):
         """
         Partition initialisation.
         """
         self.index = index
-        if part_str is None:
+        if path is None:
             self.path = ""
             self.size = 0
             self.part_type = ""
             self.fs_type = ""
         else:
-            self.path = part_str.split(" ")[0]
-            self.size = from_iec(
-                re.sub('\\s', '', stdout(execute(f'lsblk -nl "{self.path}" -o SIZE', capture_output=True, force=True))))
-            self.part_type = str(
-                re.sub('[^a-zA-Z\\d ]', '',
-                       stdout(execute(f'lsblk -nl "{self.path}" -o PARTTYPENAME', capture_output=True, force=True))))
-            self.fs_type = str(
-                re.sub('[^a-zA-Z\\d ]', '',
-                       stdout(execute(f'lsblk -nl "{self.path}" -o FSTYPE', capture_output=True, force=True))))
+            self.path = path
+            if compute:
+                self.compute()
+
+    def compute(self):
+        self.size = from_iec(re.sub('\\s', '', stdout(
+            execute(f'lsblk -nl "{self.path}" -o SIZE', capture_output=True, force=True))))
+        self.part_type = str(re.sub('[^a-zA-Z\\d ]', '', stdout(
+            execute(f'lsblk -nl "{self.path}" -o PARTTYPENAME', capture_output=True, force=True))))
+        self.fs_type = str(re.sub('[^a-zA-Z\\d ]', '', stdout(
+            execute(f'lsblk -nl "{self.path}" -o FSTYPE', capture_output=True, force=True))))
+
+    def ask_for_encryption(self):
+        self.encrypted = prompt_bool(_("Do you want to encrypt this partition ? (y/N) : "), default=False)
+        if self.encrypted:
+
+            block_name_pattern = re.compile("^[a-z][a-z\\d_]*$")
+            block_name_ok = False
+            while not block_name_ok:
+                self.block_name = prompt_ln(_("What will be the encrypted block name ? : "), required=True)
+                if self.block_name and self.block_name != "" and not block_name_pattern.match(
+                        self.block_name):
+                    print_error(_("Invalid encrypted block name."))
+                    continue
+                block_name_ok = True
+
+            self.block_password = ask_password(
+                _("Enter the encrypted block password (it will be asked at boot to decrypt the partition) : "),
+                required=True)
 
     def __str__(self) -> str:
         """
         Partition str formatting.
         """
-        return f"'{self.path}' - '{self.size}' - '{self.part_type}' - '{self.fs_type}'"
+        formatted_str = f"'{self.path}' - '{self.size}' - '{self.part_type}' - '{self.fs_type}'"
+        if self.encrypted:
+            formatted_str += f" - encrypted ('/dev/mapper/{self.block_name}')"
+        return formatted_str

--- a/src/partition.py
+++ b/src/partition.py
@@ -192,8 +192,6 @@ class Partition:
         """
         print_sub_step(_("Mounting %s...") % (self.real_path()))
         match self.part_format_type:
-            case FSFormats.VFAT:
-                execute(f'mount --mkdir "{self.real_path()}" "/mnt{self.part_mount_point}"')
             case FSFormats.BTRFS:
                 execute(f'mount --mkdir -o compress=zstd "{self.real_path()}" "/mnt{self.part_mount_point}"')
             case _:
@@ -206,8 +204,10 @@ class Partition:
         :return:
         """
         try:
+            print_sub_step(_("Unmounting %s...") % (self.real_path()))
             execute(f'umount "/mnt{self.part_mount_point}"')
             if self.encrypted:
+                print_sub_step(_("Closing %s...") % (self.real_path()))
                 execute(f'cryptsetup close {self.block_name}')
             self.part_mounted = False
         except CalledProcessError:

--- a/src/partition.py
+++ b/src/partition.py
@@ -8,7 +8,7 @@ from subprocess import CalledProcessError
 from src.i18n import I18n
 from src.options import PartTypes, FSFormats
 from src.utils import execute, stdout, prompt_bool, to_iec, \
-    ask_format_type, ask_encryption_block_name, from_iec
+    ask_format_type, ask_encryption_block_name, from_iec, print_sub_step
 
 _ = I18n().gettext
 
@@ -164,6 +164,7 @@ class Partition:
         """
         A method to execute formatting commands for the partition.
         """
+        print_sub_step(_("Formatting %s...") % (self.real_path()))
         if self.part_type == PartTypes.SWAP:
             execute(f'mkswap "{self.path}"')
             execute(f'swapon "{self.path}"')
@@ -171,6 +172,8 @@ class Partition:
         if self.encrypted:
             if self.part_format:
                 execute(f"cryptsetup -y -v luksFormat {self.path}")
+            print_sub_step(_("Opening %s...") % (self.real_path()))
+            execute(f"cryptsetup open {self.path} {self.block_name}")
         match self.part_format_type:
             case FSFormats.VFAT:
                 if self.part_format:
@@ -187,8 +190,7 @@ class Partition:
         A method to mount the partition.
         :return:
         """
-        if self.encrypted:
-            execute(f"cryptsetup open {self.path} {self.block_name}")
+        print_sub_step(_("Mounting %s...") % (self.real_path()))
         match self.part_format_type:
             case FSFormats.VFAT:
                 execute(f'mount --mkdir "{self.real_path()}" "/mnt{self.part_mount_point}"')

--- a/src/partition.py
+++ b/src/partition.py
@@ -204,9 +204,9 @@ class Partition:
         :return:
         """
         try:
-            execute(f'umount "/mnt{self.part_mount_point}')
+            execute(f'umount "/mnt{self.part_mount_point}"')
             if self.encrypted:
-                execute(f"cryptsetup close {self.block_name}")
+                execute(f'cryptsetup close {self.block_name}')
             self.part_mounted = False
         except CalledProcessError:
             return False

--- a/src/partitioninginfo.py
+++ b/src/partitioninginfo.py
@@ -1,0 +1,17 @@
+"""
+The module of PartitioningInfo class.
+"""
+from src.partition import Partition
+
+
+class PartitioningInfo:
+    """
+    The class to contain all partitioning information.
+    """
+    partitions: [Partition]
+    root_partition: Partition
+    swapfile_size: str
+    main_disk: str
+
+    def __init__(self) -> None:
+        self.partitions = []

--- a/src/partitioninginfo.py
+++ b/src/partitioninginfo.py
@@ -1,7 +1,12 @@
 """
 The module of PartitioningInfo class.
 """
+from src.i18n import I18n
+from src.options import FSFormats
 from src.partition import Partition
+from src.utils import print_step
+
+_ = I18n().gettext
 
 
 class PartitioningInfo:
@@ -13,5 +18,28 @@ class PartitioningInfo:
     swapfile_size: str
     main_disk: str
 
+    btrfs_in_use: bool = False
+
     def __init__(self) -> None:
         self.partitions = []
+
+    def format_and_mount_partitions(self):
+        """
+        A method to format and mount all partitions.
+        :return:
+        """
+        print_step(_("Formatting and mounting partitions..."), clear=False)
+
+        for partition in self.partitions:
+            if partition.part_format_type == FSFormats.BTRFS:
+                self.btrfs_in_use = True
+            partition.format_partition()
+
+        if self.root_partition.part_format_type == FSFormats.BTRFS:
+            self.btrfs_in_use = True
+        self.root_partition.mount()
+
+        for partition in [partition for partition in self.partitions if not partition.part_mounted]:
+            if partition.part_format_type == FSFormats.BTRFS:
+                self.btrfs_in_use = True
+            partition.mount()

--- a/src/partitioninginfo.py
+++ b/src/partitioninginfo.py
@@ -8,7 +8,7 @@ class PartitioningInfo:
     """
     The class to contain all partitioning information.
     """
-    partitions: [Partition]
+    partitions: list[Partition]
     root_partition: Partition
     swapfile_size: str
     main_disk: str

--- a/src/partitioninginfo.py
+++ b/src/partitioninginfo.py
@@ -46,6 +46,9 @@ class PartitioningInfo:
                     self.btrfs_in_use = True
                 partition.mount()
 
+        for partition in self.partitions:
+            partition.compute()
+
     def umount_partitions(self):
         """
         A method to unmount all mounted partitions.

--- a/src/partitioninginfo.py
+++ b/src/partitioninginfo.py
@@ -1,10 +1,12 @@
 """
 The module of PartitioningInfo class.
 """
+import re
+
 from src.i18n import I18n
 from src.options import FSFormats
 from src.partition import Partition
-from src.utils import print_step
+from src.utils import print_step, stdout, execute
 
 _ = I18n().gettext
 
@@ -35,11 +37,28 @@ class PartitioningInfo:
                 self.btrfs_in_use = True
             partition.format_partition()
 
-        if self.root_partition.part_format_type == FSFormats.BTRFS:
-            self.btrfs_in_use = True
-        self.root_partition.mount()
+        not_mounted_partitions = [partition for partition in self.partitions if not partition.part_mounted]
+        not_mounted_partitions.sort(key=lambda part: len(part.part_mount_point))
 
-        for partition in [partition for partition in self.partitions if not partition.part_mounted]:
-            if partition.part_format_type == FSFormats.BTRFS:
-                self.btrfs_in_use = True
-            partition.mount()
+        while False in [partition.part_mounted for partition in not_mounted_partitions]:
+            for partition in not_mounted_partitions:
+                if partition.part_format_type == FSFormats.BTRFS:
+                    self.btrfs_in_use = True
+                partition.mount()
+
+    def umount_partitions(self):
+        """
+        A method to unmount all mounted partitions.
+        """
+        print_step(_("Unmounting partitions..."), clear=False)
+        swap = re.sub('\\s', '',
+                      stdout(execute('swapon --noheadings | awk \'{print $1}\'', check=False, capture_output=True)))
+        if swap != "":
+            execute(f'swapoff {swap} &>/dev/null', check=False)
+
+        mounted_partitions = [partition for partition in self.partitions if partition.part_mounted]
+        mounted_partitions.sort(key=lambda partition: len(partition.part_mount_point), reverse=True)
+
+        while True in [partition.part_mounted for partition in mounted_partitions]:
+            for partition in [partition for partition in mounted_partitions if partition.part_mounted]:
+                partition.umount()

--- a/src/systemsetup.py
+++ b/src/systemsetup.py
@@ -115,7 +115,7 @@ def setup_system(detected_timezone) -> dict[str, any]:
             pkgs_select_ok = True
             if more_pkgs_str != "":
                 for pkg in more_pkgs_str.split():
-                    if execute(f'pacman -Si {pkg} &>/dev/null').returncode != 0:
+                    if execute(f'pacman -Si {pkg} &>/dev/null', check=False).returncode != 0:
                         pkgs_select_ok = False
                         print_error(_("Package %s doesn't exist.") % pkg)
                         break

--- a/src/systemsetup.py
+++ b/src/systemsetup.py
@@ -24,7 +24,7 @@ from src.utils import print_error, print_step, print_sub_step, prompt_ln, prompt
 _ = I18n().gettext
 
 
-def setup_system(detected_timezone) -> {}:
+def setup_system(detected_timezone) -> dict[str, any]:
     """
     The method to get system configurations from the user.
     :param detected_timezone:

--- a/src/systemsetup.py
+++ b/src/systemsetup.py
@@ -121,9 +121,11 @@ def setup_system(detected_timezone) -> {}:
                         break
                     system_info["more_pkgs"].add(pkg)
 
-        system_info["root_password"] = ask_password()
+        print_sub_step(_("%s password configuration : ") % "root")
+        system_info["root_password"] = ask_password(_("Enter the %s password : ") % "root")
         if system_info["user_name"] != "":
-            system_info["user_password"] = ask_password(system_info["user_name"])
+            print_sub_step(_("%s password configuration : ") % system_info["user_name"])
+            system_info["user_password"] = ask_password(_("Enter the %s password : ") % system_info["user_name"])
 
         system_info["bootloader"] = Grub(BootLoaders.GRUB)
         system_info["microcodes"] = Microcodes()

--- a/src/utils.py
+++ b/src/utils.py
@@ -312,7 +312,7 @@ def execute(command: str, check: bool = True, capture_output: bool = False,
     return fake_result
 
 
-def stdout(process_result: subprocess.CompletedProcess):
+def stdout(process_result: subprocess.CompletedProcess) -> str:
     """
     A method to get a decoded stdout.
     :param process_result:

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,9 +56,9 @@ def ask_format_type() -> FSFormats:
                          FSFormats, _("Supported format types : "), FSFormats.EXT4, FSFormats.VFAT)
 
 
-def ask_encryption_credentials() -> tuple[str, str]:
+def ask_encryption_block_name() -> str:
     """
-    Method to ask for encryption credentials.
+    Method to ask for encryption block name.
     :return:
     """
     block_name_pattern = re.compile("^[a-z][a-z\\d_]*$")
@@ -71,11 +71,7 @@ def ask_encryption_credentials() -> tuple[str, str]:
             print_error(_("Invalid encrypted block name."))
             continue
         block_name_ok = True
-
-    block_password = ask_password(
-        _("Enter the encrypted block password (it will be asked at boot to decrypt the partition) : "),
-        required=True)
-    return block_name, block_password
+    return block_name
 
 
 def ask_password(prompt_message: str, required: bool = False) -> str:

--- a/src/utils.py
+++ b/src/utils.py
@@ -56,6 +56,28 @@ def ask_format_type() -> FSFormats:
                          FSFormats, _("Supported format types : "), FSFormats.EXT4, FSFormats.VFAT)
 
 
+def ask_encryption_credentials() -> tuple[str, str]:
+    """
+    Method to ask for encryption credentials.
+    :return:
+    """
+    block_name_pattern = re.compile("^[a-z][a-z\\d_]*$")
+    block_name_ok = False
+    block_name = None
+    while not block_name_ok:
+        block_name = prompt_ln(_("What will be the encrypted block name ? : "), required=True)
+        if block_name and block_name != "" and not block_name_pattern.match(
+                block_name):
+            print_error(_("Invalid encrypted block name."))
+            continue
+        block_name_ok = True
+
+    block_password = ask_password(
+        _("Enter the encrypted block password (it will be asked at boot to decrypt the partition) : "),
+        required=True)
+    return block_name, block_password
+
+
 def ask_password(prompt_message: str, required: bool = False) -> str:
     """
     A method to ask a password to the user.


### PR DESCRIPTION
TO-DO LIST:

- [x] Add encryption informations in partition class
- [x] Make the partition class contain the partition formatting and mounting intelligence
- [x] Add a boot partition type in the manual partitioning
- [x] Refactor the partitioning_info dict to use the partition class and add all required informations into it
- [x] Refactor the manual partitioning to ask if encryption is desired for each encryptable partitions. If encryption is desired then it is not possible to not format the partition
- [x] Refactor the automatic partitioning to ask if encryption is desired for root and home if separated home is chosen
- [x] Add the generation of a boot partition in automatic partitioning if root is encrypted
- [x] Implement the encryption formatting and mounting specifics
- [x] Add mkinitcpio configurations in grub bundle if there is an encrypted partitions 
- [x] Add grub configurations in grub bundle if there is an encrypted partitions
- [x] Test and debug